### PR TITLE
Potential fix for code scanning alert no. 55: Disallow the `any` type

### DIFF
--- a/passcheck/src/utils/api.ts
+++ b/passcheck/src/utils/api.ts
@@ -66,7 +66,7 @@ const tokenConfig = () => {
   return config;
 };
 
-const throwApiError = (error: AxiosError<unknown, any> | string) => {
+const throwApiError = (error: AxiosError<unknown> | string) => {
   let message = "";
   if (typeof error === "string") {
     message = error;
@@ -77,7 +77,7 @@ const throwApiError = (error: AxiosError<unknown, any> | string) => {
       error.response.data !== null &&
       "detail" in error.response.data
     ) {
-      message = error.response?.data?.detail as string;
+      message = (error.response.data as { detail: string }).detail;
     }
   }
   const apiError: ApiError = {


### PR DESCRIPTION
Potential fix for [https://github.com/dachrisch/leaguesphere/security/code-scanning/55](https://github.com/dachrisch/leaguesphere/security/code-scanning/55)

To fix the problem, we need to replace the `any` type with a more specific type that accurately represents the possible values. In this case, we can use `unknown` instead of `any` for the `error` parameter in the `throwApiError` function. The `unknown` type is safer than `any` because it forces us to perform type checks before using the value. Additionally, we can define a more specific type for the `error.response.data` to ensure type safety.

1. Replace `any` with `unknown` in the `throwApiError` function signature.
2. Perform type checks within the `throwApiError` function to handle the `unknown` type safely.
3. Define a more specific type for `error.response.data` if possible.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
