### PR TITLE
fix: add internal production domains to ALLOWED_HOSTS

### DIFF
--- a/league_manager/settings/prod.py
+++ b/league_manager/settings/prod.py
@@ -12,6 +12,7 @@ ALLOWED_HOSTS = [
     "stage.leaguesphere.app",
     "www.stage.leaguesphere.app",
     "leaguesphere.servyy-test.lxd",
+    "leaguesphere.lehel.xyz",
 ]
 CSRF_TRUSTED_ORIGINS = [
     "https://leaguesphere.app",
@@ -19,6 +20,7 @@ CSRF_TRUSTED_ORIGINS = [
     "https://stage.leaguesphere.app",
     "https://www.stage.leaguesphere.app",
     "https://leaguesphere.servyy-test.lxd",
+    "https://leaguesphere.lehel.xyz",
 ]
 
 # Sitemap domain for production


### PR DESCRIPTION
Resolves DisallowedHost exceptions for leaguesphere.lehel.xyz reported in Grafana logs. These requests likely originate from internal monitoring or health check services.