### PR TITLE
fix(passcheck): handle DoesNotExist exceptions to prevent 5xx errors

### DIFF
--- a/passcheck/views.py
+++ b/passcheck/views.py
@@ -125,7 +125,10 @@ class PlayerlistUpdateView(PlayerlistCommonMixin, UserPassesTestMixin, UpdateVie
         return reverse(PASSCHECK_ROSTER_LIST, kwargs={"pk": self.object.team_id})
 
     def test_func(self):
-        player = Playerlist.objects.get(pk=self.kwargs.get("pk"))
+        try:
+            player = Playerlist.objects.get(pk=self.kwargs.get("pk"))
+        except Playerlist.DoesNotExist:
+            return False
         return PermissionHelper.has_staff_or_user_permission(
             self.request, player.team_id
         )
@@ -203,7 +206,10 @@ class PlayerlistTransferView(PlayerlistCommonMixin, UserPassesTestMixin, UpdateV
             status="approved", current_team=pk
         ).exists():
             return False
-        player = Playerlist.objects.get(pk=pk)
+        try:
+            player = Playerlist.objects.get(pk=pk)
+        except Playerlist.DoesNotExist:
+            return False
         return PermissionHelper.has_staff_or_user_permission(
             self.request, player.team_id
         )
@@ -214,7 +220,7 @@ class PasscheckPlayerGamesList(View):
 
     def get(self, request, **kwargs):
         player_id = kwargs.get("pk")
-        player = Playerlist.objects.get(pk=player_id)
+        player = get_object_or_404(Playerlist, pk=player_id)
         user_permission = PermissionHelper.get_user_request_permission(
             self.request, player.team_id
         )


### PR DESCRIPTION
## Summary
Fixes production 5xx errors where non-existent player IDs were causing unhandled DoesNotExist exceptions.

## Changes
- Replace bare `Playerlist.objects.get()` calls with proper exception handling in three views
- `PasscheckPlayerGamesList.get()`: Use `get_object_or_404()` for proper 404 response
- `PlayerlistUpdateView.test_func()`: Catch `DoesNotExist` → return False (triggers 403)
- `PlayerlistTransferView.test_func()`: Catch `DoesNotExist` → return False (triggers 403)

## Root Cause
Production logs showed 5xx errors when accessing non-existent player IDs. The endpoint raised unhandled `Playerlist.DoesNotExist` exceptions instead of returning proper HTTP responses (404/403).

## Testing
- Player endpoint now returns 404 for non-existent players
- Update/transfer views return 403 for missing players
- No changes to business logic, only error handling

🤖 Generated with [Claude Code](https://claude.ai/code)