### PR TITLE
fix(schedule,passcheck): handle missing gameinfo and invalid team references

### DIFF
--- a/gamedays/management/schedule_manager.py
+++ b/gamedays/management/schedule_manager.py
@@ -160,7 +160,13 @@ class Schedule:
             return home_placeholder
         group_index = int(tmp[0])
         team_index = int(tmp[1])
-        return self.groups[group_index].teams[team_index]
+        try:
+            return self.groups[group_index].teams[team_index]
+        except (IndexError, AttributeError):
+            raise ValueError(
+                f"Schedule format references invalid team: group {group_index}, position {team_index}. "
+                f"Verify schedule template matches team count in groups."
+            )
 
     def _format_match_number_of_teams(self):
         number_of_teams = int(self.format.split("_")[0])

--- a/gamedays/wizard/gameday_format.py
+++ b/gamedays/wizard/gameday_format.py
@@ -32,7 +32,10 @@ class GamedayFormatStepHandler(WizardStepHandler):
         needed_teams = [group[SCHEDULE_MAP_TEAMS_C] for group in groups]
         number_groups = len(groups)
         if len(group_array) > 0 and len(group_array) != len(groups):
-            raise ValueError("ungleiche Anzahl an Gruppen!")
+            raise ValueError(
+                f"Mismatch in group count: schedule format requires {len(groups)} group(s), "
+                f"but {len(group_array)} group(s) were provided."
+            )
         formset = get_gameday_format_formset(
             extra=len(groups),
             needed_teams_list=needed_teams,

--- a/passcheck/service/passcheck_service.py
+++ b/passcheck/service/passcheck_service.py
@@ -361,6 +361,8 @@ class PasscheckService:
         gameinfo = Gameinfo.objects.filter(
             officials_id=team, gameday__in=today_gamedays
         ).order_by("scheduled")
+        if not gameinfo.exists():
+            return {"completed": False}
         games_to_check = gameinfo.filter(scheduled__lte=gameinfo.first().scheduled)
         number_of_teams_to_check = games_to_check.count() * 2
         verified_teams = PasscheckVerification.objects.filter(


### PR DESCRIPTION
## Summary
Fixes three production errors related to schedule handling and passcheck:

- **AttributeError**: passcheck status endpoint (4 occurrences)
- **IndexError**: schedule template processing (4 occurrences)  
- **ValueError**: improved error message for group mismatch (1 occurrence)

## Changes

### 1. passcheck_service.get_passcheck_status() - AttributeError fix
When an official team has no games scheduled, `gameinfo.first()` returns None, causing crash when accessing `.scheduled`.

**Fix:** Check `if not gameinfo.exists()` before accessing first element, return `{"completed": False}` early.

### 2. schedule_manager._replace_placeholder_by_group_entry() - IndexError fix  
Schedule placeholders reference group/team indices that may not exist in the actual team groups.

**Fix:** Wrap array access in try/except, provide descriptive error showing which index failed.

### 3. gameday_format.handle_form() - Better error message
User provides mismatched group count for schedule template. Error message is cryptic German ("ungleiche Anzahl an Gruppen").

**Fix:** Replace with English message showing expected vs provided group counts.

## Testing
- Passcheck status endpoint returns `{"completed": false}` when no games scheduled (instead of 500)
- Schedule processing with invalid placeholders shows which group/team index failed
- Group count mismatch shows expected vs actual counts in error

🤖 Generated with [Claude Code](https://claude.ai/code)