### PR TITLE
fix(gamedays,officials,passcheck): handle None values and non-iterable types

### DIFF
--- a/gamedays/views.py
+++ b/gamedays/views.py
@@ -164,7 +164,10 @@ class GamedayDetailView(DetailView):
             if self.request.user.is_staff:
                 show_official_names = True
             elif self.request.user.username:
-                show_official_names = self.request.user.username in qualify_table
+                try:
+                    show_official_names = self.request.user.username in qualify_table
+                except TypeError:
+                    show_official_names = False
             from officials.service.signup_service import OfficialSignupService
 
             officials = OfficialSignupService.get_signed_up_officials(

--- a/officials/service/boff_license_calculation.py
+++ b/officials/service/boff_license_calculation.py
@@ -146,9 +146,8 @@ class LicenseCalculator:
 
 class ParticipationValidator:
     def __init__(self, course_license):
-        self.course = LicenseStrategy.COURSE_MAPPING(course_license).get(
-            "user_current_license"
-        )
+        course_map = LicenseStrategy.COURSE_MAPPING(course_license)
+        self.course = course_map.get("user_current_license") if course_map else None
 
     def fails_minimum_season_games(self, participant_license, minimum_season_games):
         return self._evaluate_requirement(

--- a/passcheck/service/passcheck_service.py
+++ b/passcheck/service/passcheck_service.py
@@ -121,6 +121,8 @@ class PasscheckService:
 
     def get_roster(self, team_id: int, year: int, gameday_id: int = None):
         team = self._get_team(team_id)
+        if team is None:
+            raise ValueError(f"Team {team_id} not found")
         years = (
             Playerlist.objects.filter(team=team)
             .exclude(gamedays__league__name=None)


### PR DESCRIPTION
## Summary
Fixes three production errors related to type mismatches and None handling:

- **TypeError**: EmptyQualifyTable not iterable (33 occurrences)
- **AttributeError**: NoneType.get in license calculation (3 occurrences)
- **AttributeError**: Team.description when team is None (7 occurrences)

## Changes

### 1. gamedays/views.py:167 - EmptyQualifyTable TypeError (33x)
The `in` operator doesn't work on EmptyQualifyTable objects (missing `__contains__` method).

**Fix:** Wrap membership check in try/except, default to `False` on TypeError
```python
try:
    show_official_names = self.request.user.username in qualify_table
except TypeError:
    show_official_names = False
```

### 2. officials/boff_license_calculation.py:149 - License mapping returns None (3x)
`LicenseStrategy.COURSE_MAPPING()` returns None for unknown licenses, but code calls `.get()` on it.

**Fix:** Check if mapping exists before calling `.get()`
```python
course_map = LicenseStrategy.COURSE_MAPPING(course_license)
self.course = course_map.get("user_current_license") if course_map else None
```

### 3. passcheck/service/passcheck_service.py:122 - Team lookup returns None (7x)
`_get_team()` returns None for invalid team IDs, but code accesses `.description` without checking.

**Fix:** Raise descriptive ValueError early
```python
team = self._get_team(team_id)
if team is None:
    raise ValueError(f"Team {team_id} not found")
```

## Result
- EmptyQualifyTable errors return False for membership instead of 500
- License validation handles unknown license types gracefully
- Invalid team IDs return meaningful error message instead of AttributeError

🤖 Generated with [Claude Code](https://claude.ai/code)