### PR TITLE
fix: quote if condition in release-please-automerge workflow YAML

### DIFF
--- a/.github/workflows/release-please-automerge.yaml
+++ b/.github/workflows/release-please-automerge.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
     steps:
       - uses: actions/checkout@v4
       - name: Check if patch-only release


### PR DESCRIPTION
Fixes YAML syntax error in release-please-automerge.yaml that prevented the workflow from running. GitHub Actions requires job-level if conditions with wildcard label filters to be quoted.