### PR TITLE
Rename 'Game Progress' to 'Live Status' in Orga menu

### DIFF
--- a/gameday_designer/menu.py
+++ b/gameday_designer/menu.py
@@ -40,7 +40,7 @@ class Gameday_designerMenuOrgaEntry(BaseMenu):
                 url="gameday_designer_app:index",  # Reverses to /gamedays/gameday/design/
             ),
             MenuItem.create(
-                name='📊 Game Progress',
+                name='📊 Live Status',
                 url="game-progress-page",  # Reverses to /gamedays/progress/
             ),
         ]


### PR DESCRIPTION
Renames the game progress menu entry from '📊 Game Progress' to '📊 Live Status' to better reflect the functionality.