### PR TITLE
chore: sync uv.lock in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,16 @@ commands:
             - .venv
           key: v2-dependencies-{{ checksum "pyproject.toml" }}
 
+  ensure_lockfile:
+    steps:
+      - run:
+          name: Ensure uv.lock is up to date
+          command: |
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV
+            source $BASH_ENV
+            uv lock
+
   build_docker_image:
     parameters:
       dockerfile:
@@ -282,6 +292,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - ensure_lockfile
       - setup_remote_docker:
           version: 20.10.24
           docker_layer_caching: true
@@ -295,6 +306,7 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
+      - ensure_lockfile
       - setup_remote_docker:
           version: 20.10.24
           docker_layer_caching: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: uv-lock
+        name: uv lock
+        entry: bash -c 'uv lock'
+        language: system
+        files: ^pyproject\.toml$
+        pass_filenames: false
+        stages: [commit]


### PR DESCRIPTION
Ensure uv.lock stays synchronized during builds and releases

- Add pre-commit hook to auto-regenerate uv.lock when pyproject.toml changes
- Add ensure_lockfile command in CircleCI as fallback before Docker builds
- Ensures lockfile stays in sync locally, during release, and in CI pipeline

Fixes stale uv.lock causing Docker build failures in release pipeline