### PR TITLE
feat: dynamic live/upcoming status for today's gamedays

### DIFF
--- a/container/app.Dockerfile
+++ b/container/app.Dockerfile
@@ -30,7 +30,7 @@ ARG APP_USER="django"
 ARG APP_DIR="/app"
 
 RUN apt -y update && \
-    apt -y install curl jq default-libmysqlclient-dev
+    apt -y install curl jq default-libmysqlclient-dev mariadb-client
 
 # add user
 RUN adduser --disabled-password --home ${APP_DIR} ${APP_USER}
@@ -42,11 +42,12 @@ COPY --from=app-builder --chown=${APP_USER}:${APP_USER} /app/.venv ${APP_DIR}/.v
 COPY --chown=${APP_USER}:${APP_USER} . ${APP_DIR}
 COPY --chown=${APP_USER}:${APP_USER} container/entrypoint.sh /app/entrypoint.sh
 COPY --chown=${APP_USER}:${APP_USER} container/entrypoint.demo.sh /app/entrypoint.demo.sh
+COPY --chown=${APP_USER}:${APP_USER} container/entrypoint.staging.sh /app/entrypoint.staging.sh
 
 USER ${APP_USER}
 WORKDIR ${APP_DIR}
 
-RUN rm -rf .git/ && chmod 740 /app/entrypoint.sh /app/entrypoint.demo.sh
+RUN rm -rf .git/ && chmod 740 /app/entrypoint.sh /app/entrypoint.demo.sh /app/entrypoint.staging.sh
 
 # Use the virtual environment
 ENV PATH="${APP_DIR}/.venv/bin:${PATH}"

--- a/container/entrypoint.staging.sh
+++ b/container/entrypoint.staging.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $1"; }
+
+log "Syncing production DB to staging..."
+DUMP_FILE="/tmp/prod_dump_$(date +%s).sql"
+
+log "Dumping ${PROD_MYSQL_DB_NAME} from ${PROD_MYSQL_HOST}..."
+mysqldump \
+  -h "$PROD_MYSQL_HOST" \
+  -u "$PROD_MYSQL_USER" \
+  -p"$PROD_MYSQL_PWD" \
+  --no-tablespaces \
+  --single-transaction \
+  --skip-triggers \
+  "$PROD_MYSQL_DB_NAME" > "$DUMP_FILE"
+
+log "Recreating staging database..."
+mysql -h "$MYSQL_HOST" -u root -p"$MYSQL_ROOT_PASSWORD" <<SQL
+DROP DATABASE IF EXISTS \`${MYSQL_DB_NAME}\`;
+CREATE DATABASE \`${MYSQL_DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+GRANT ALL PRIVILEGES ON \`${MYSQL_DB_NAME}\`.* TO '${MYSQL_USER}'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+log "Importing production data..."
+mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PWD" "$MYSQL_DB_NAME" < "$DUMP_FILE"
+rm -f "$DUMP_FILE"
+log "Sync complete"
+
+log "Running migrations..."
+python manage.py migrate --noinput || { log "Migrations failed"; exit 1; }
+
+exec "$@"

--- a/deployed/docker-compose.staging.yaml
+++ b/deployed/docker-compose.staging.yaml
@@ -67,6 +67,7 @@ services:
   staging-app:
     image: leaguesphere/backend:staging
     container_name: ${COMPOSE_PROJECT_NAME}.staging-app
+    entrypoint: /app/entrypoint.staging.sh
     command: gunicorn -b 0.0.0.0:8000 league_manager.wsgi
     healthcheck:
       test: ["CMD-SHELL", "curl -A healthcheck -H \"Accept: application/json\" http://localhost:8000/health/?format=json"]
@@ -83,7 +84,6 @@ services:
     env_file: ls.env.staging
     environment:
       DJANGO_SETTINGS_MODULE: league_manager.settings.stage
-      RUN_MIGRATIONS: true
     networks:
       - backend
       - egress

--- a/deployed/ls.env.staging.template
+++ b/deployed/ls.env.staging.template
@@ -1,6 +1,12 @@
 # LeagueSphere Staging Environment Variables
 # This is a template file - copy to ls.env.staging and fill in actual values
 
+# Production DB (source for sync on container start)
+PROD_MYSQL_HOST=s207.goserver.host
+PROD_MYSQL_USER=<PROD_DB_USER>
+PROD_MYSQL_PWD=<PROD_DB_PASSWORD>
+PROD_MYSQL_DB_NAME=<PROD_DB_NAME>
+
 # MySQL Configuration (staging-specific database)
 MYSQL_HOST=mysql
 MYSQL_DB_NAME=leaguesphere_staging

--- a/gameday_designer/package-lock.json
+++ b/gameday_designer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gameday_designer",
-  "version": "3.19.10",
+  "version": "3.19.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gameday_designer",
-      "version": "3.19.10",
+      "version": "3.19.12",
       "dependencies": {
         "@types/node": "25.9.1",
         "@types/react": "19.2.15",
@@ -2166,9 +2166,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,9 +2183,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2206,9 +2200,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2226,9 +2217,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2246,9 +2234,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,9 +2251,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,9 +2444,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2482,9 +2461,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2502,9 +2478,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2522,9 +2495,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2542,9 +2512,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2562,9 +2529,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5037,9 +5001,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5061,9 +5022,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5085,9 +5043,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5109,9 +5064,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/journey/api/progress_serializers.py
+++ b/journey/api/progress_serializers.py
@@ -72,14 +72,16 @@ class GamedayProgressSerializer(serializers.ModelSerializer):
 
     def get_computed_status(self, obj):
         """Compute status from games when Gameday.status is empty."""
-        if obj.status:
+        gameday_has_status = obj.status is not None and obj.status != ''
+        if gameday_has_status:
             return None
 
         games = obj.gameinfo_set.all()
-        if not games:
+        has_games = games.exists()
+        if not has_games:
             return 'PUBLISHED'
 
         statuses = [game.status for game in games]
-        all_completed = all(status == 'beendet' for status in statuses)
+        all_completed = all(status == Gameinfo.STATUS_COMPLETED for status in statuses)
 
         return 'COMPLETED' if all_completed else 'PUBLISHED'

--- a/journey_dashboard/package-lock.json
+++ b/journey_dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "journey_dashboard",
-  "version": "3.19.10",
+  "version": "3.19.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "journey_dashboard",
-      "version": "3.19.10",
+      "version": "3.19.11",
       "dependencies": {
         "@types/node": "25.9.1",
         "@types/react": "19.2.15",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
-      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -137,6 +137,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -579,6 +580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -627,6 +629,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -637,6 +640,7 @@
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -648,6 +652,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1353,9 +1358,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
-      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1753,9 +1758,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1773,9 +1775,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1793,9 +1792,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,9 +1809,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1833,9 +1826,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,9 +1843,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,9 +1937,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/core": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
-      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
+      "integrity": "sha512-jOlwnFV2xhuuZeAUILGFULeR6vDPfijEJ57evfocwznQldLU3w2cZ9bSDryY9ip+AsM3r1NJKzf47V2NXebkeQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1968,18 +1955,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.40",
-        "@swc/core-darwin-x64": "1.15.40",
-        "@swc/core-linux-arm-gnueabihf": "1.15.40",
-        "@swc/core-linux-arm64-gnu": "1.15.40",
-        "@swc/core-linux-arm64-musl": "1.15.40",
-        "@swc/core-linux-ppc64-gnu": "1.15.40",
-        "@swc/core-linux-s390x-gnu": "1.15.40",
-        "@swc/core-linux-x64-gnu": "1.15.40",
-        "@swc/core-linux-x64-musl": "1.15.40",
-        "@swc/core-win32-arm64-msvc": "1.15.40",
-        "@swc/core-win32-ia32-msvc": "1.15.40",
-        "@swc/core-win32-x64-msvc": "1.15.40"
+        "@swc/core-darwin-arm64": "1.15.33",
+        "@swc/core-darwin-x64": "1.15.33",
+        "@swc/core-linux-arm-gnueabihf": "1.15.33",
+        "@swc/core-linux-arm64-gnu": "1.15.33",
+        "@swc/core-linux-arm64-musl": "1.15.33",
+        "@swc/core-linux-ppc64-gnu": "1.15.33",
+        "@swc/core-linux-s390x-gnu": "1.15.33",
+        "@swc/core-linux-x64-gnu": "1.15.33",
+        "@swc/core-linux-x64-musl": "1.15.33",
+        "@swc/core-win32-arm64-msvc": "1.15.33",
+        "@swc/core-win32-ia32-msvc": "1.15.33",
+        "@swc/core-win32-x64-msvc": "1.15.33"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -1991,9 +1978,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.33.tgz",
+      "integrity": "sha512-N+L0uXhuO7FIfzqwgxmzv0zIpV0qEp8wPX3QQs2p4atjMoywup2JTeDlXPw+z9pWJGCae3JjM+tZ6myclI+2gA==",
       "cpu": [
         "arm64"
       ],
@@ -2008,9 +1995,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.33.tgz",
+      "integrity": "sha512-/Il4QHSOhV4FekbsDtkrNmKbsX26oSysvgrRswa/RYOHXAkwXDbB4jaeKq6PsJLSPkzJ2KzQ061gtBnk0vNHfA==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2012,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.33.tgz",
+      "integrity": "sha512-C64hBnBxq4viOPQ8hlx+2lJ23bzZBGnjw7ryALmS+0Q3zHmwO8lw1/DArLENw4Q18/0w5wdEO1k3m1wWNtKGqQ==",
       "cpu": [
         "arm"
       ],
@@ -2042,16 +2029,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.33.tgz",
+      "integrity": "sha512-TRJfnJbX3jqpxRDRoieMzRiCBS5jOmXNb3iQXmcgjFEHKLnAgK1RZRU8Cq1MsPqO4jAJp/ld1G4O3fXuxv85uw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2062,16 +2046,13 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.33.tgz",
+      "integrity": "sha512-il7tYM+CpUNzieQbwAjFT1P8zqAhmGWNAGhQZBnxurXZ0aNn+5nqYFTEUKNZl7QibtT0uQXzTZrNGHCIj6Y1Og==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2082,16 +2063,13 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.33.tgz",
+      "integrity": "sha512-ZtNBwN0Z7CFj9Il0FcPaKdjgP7URyKu/3RfH46vq+0paOBqLj4NYldD6Qo//Duif/7IOtAraUfDOmp0PLAufog==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2102,16 +2080,13 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.33.tgz",
+      "integrity": "sha512-De1IyajoOmhOYYjw/lx66bKlyDpHZTueqwpDrWgf5O7T6d1ODeJJO9/OqMBmrBQc5C+dNnlmIufHsp4QVCWufA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2122,16 +2097,13 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.33.tgz",
+      "integrity": "sha512-mGTH0YxmUN+x6vRN/I6NOk5X0ogNktkwPnJ94IMvR7QjhRDwL0O8RXEDhyUM0YtwWrryBOqaJQBX4zruxEPRGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2142,16 +2114,13 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.33.tgz",
+      "integrity": "sha512-hj628ZkSEJf6zMf5VMbYrG2O6QqyTIp2qwY6VlCjvIa9lAEZ5c2lfPblCLVGYubTeLJDxadLB/CxqQYOQABeEQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2162,9 +2131,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.33.tgz",
+      "integrity": "sha512-GV2oohtN2/5+KSccl86VULu3aT+LrISC8uzgSq0FRnikpD+Zwc+sBlXmoKQ+Db6jI57ITUOIB8jRkdGMABC29g==",
       "cpu": [
         "arm64"
       ],
@@ -2179,9 +2148,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.33.tgz",
+      "integrity": "sha512-gtyvzSNR8DHKfFEA2uqb8Ld1myqi6uEg2jyeUq3ikn5ytYs7H8RpZYC8mdy4NXr8hfcdJfCLXPlYaqqfBXpoEQ==",
       "cpu": [
         "ia32"
       ],
@@ -2196,9 +2165,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "version": "1.15.33",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.33.tgz",
+      "integrity": "sha512-d6fRqQSkJI+kmMEBWaDQ7TMl8+YjLYbwRUPZQ9DY0ORBJeTzOrG0twvfvlZ2xgw6jA0ScQKgfBm4vHLSLl5Hqg==",
       "cpu": [
         "x64"
       ],
@@ -2244,6 +2213,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2396,6 +2366,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -2417,6 +2388,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2426,6 +2398,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2513,6 +2486,7 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -2743,6 +2717,7 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -2872,6 +2847,7 @@
       "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.7",
         "fflate": "^0.8.2",
@@ -2909,6 +2885,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3073,9 +3050,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3128,6 +3105,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3430,9 +3408,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
     },
@@ -3484,9 +3462,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3517,6 +3495,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3580,6 +3559,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4153,6 +4133,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -4396,9 +4377,9 @@
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4624,9 +4605,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4648,9 +4626,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4672,9 +4647,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4696,9 +4668,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4847,9 +4816,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4971,14 +4940,11 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5147,6 +5113,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5268,6 +5235,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5329,6 +5297,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5742,9 +5711,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
-      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5779,22 +5748,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.1.2.tgz",
-      "integrity": "sha512-RUX5sQm8bl03ycwQ6nSgJiKw9FZWhA8GBzxX6X1lsG3xKzFIW+lYLLpM30FQbDD6XjTWa/VkF15VxjnAMWYJAQ==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.1.2"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.1.2.tgz",
-      "integrity": "sha512-26EbERPLf5wkNFKW+7egxArSPN1Nqipe/PIe1nvhpNu8HqQeY2pYdOeQk4sAiADv/e03VzHkLY0PPohKv1JMAQ==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5872,6 +5841,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6018,6 +5988,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6096,6 +6067,7 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -6354,6 +6326,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/journey_dashboard/package-lock.json
+++ b/journey_dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "journey_dashboard",
-  "version": "3.19.11",
+  "version": "3.19.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "journey_dashboard",
-      "version": "3.19.11",
+      "version": "3.19.12",
       "dependencies": {
         "@types/node": "25.9.1",
         "@types/react": "19.2.15",

--- a/journey_dashboard/src/components/game-progress/GameProgressPage.tsx
+++ b/journey_dashboard/src/components/game-progress/GameProgressPage.tsx
@@ -45,7 +45,9 @@ const GameProgressPage: React.FC = () => {
             <h2 className={styles.sectionTitle}>
               {state.totalLiveGames > 0 
                 ? t('ui:gameProgress.section.live', { count: state.totalLiveGames })
-                : t('ui:gameProgress.section.today_top')}
+                : state.totalPlayedGamesToday > 0
+                  ? t('ui:gameProgress.section.today_results', { count: state.live.length })
+                  : t('ui:gameProgress.section.today_top', { count: state.live.length })}
             </h2>
             <div className={styles.gamedayList}>
               {state.live.map((gameday) => (

--- a/journey_dashboard/src/components/game-progress/GameProgressPage.tsx
+++ b/journey_dashboard/src/components/game-progress/GameProgressPage.tsx
@@ -39,11 +39,13 @@ const GameProgressPage: React.FC = () => {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
-        {/* LIVE section */}
+        {/* LIVE / TODAY section */}
         {state.live.length > 0 && (
           <section className={styles.section}>
             <h2 className={styles.sectionTitle}>
-              {t('ui:gameProgress.section.live', { count: state.totalLiveGames })}
+              {state.totalLiveGames > 0 
+                ? t('ui:gameProgress.section.live', { count: state.totalLiveGames })
+                : t('ui:gameProgress.section.today_top')}
             </h2>
             <div className={styles.gamedayList}>
               {state.live.map((gameday) => (

--- a/journey_dashboard/src/components/game-progress/GamedayCard.tsx
+++ b/journey_dashboard/src/components/game-progress/GamedayCard.tsx
@@ -23,6 +23,9 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
   const gamedayUrl = `/gamedays/gameday/${gameday.id}/`;
 
   const isActuallyLive = stats.played > 0 || stats.live > 0;
+  const showProgressBar = isLive && isActuallyLive;
+  const showMinutesUntilStart = !gameday.isStale && gameday.minutesUntilStart !== undefined;
+  const showScheduledOnly = gameday.minutesUntilStart === undefined && stats.played === 0 && stats.live === 0;
 
   return (
     <a href={gamedayUrl} className={`${styles.gamedayCard} ${isLive ? styles.cardLive : ''}`} style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
@@ -35,14 +38,13 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
               <span className={styles.upcomingBadgeToday}>● {t('ui:gameProgress.card.upcomingBadge')}</span>
             )
           )}
-          {gameday.isStale ? (
+          {gameday.isStale && (
             <span className={`${styles.timeUntil} ${styles.stale}`}>{t('ui:gameProgress.card.stale')}</span>
-          ) : (
-            gameday.minutesUntilStart !== undefined && (
-              <span className={styles.timeUntil}>
-                {t('ui:gameProgress.card.minutesUntil', { minutes: gameday.minutesUntilStart })}
-              </span>
-            )
+          )}
+          {showMinutesUntilStart && (
+            <span className={styles.timeUntil}>
+              {t('ui:gameProgress.card.minutesUntil', { minutes: gameday.minutesUntilStart })}
+            </span>
           )}
           <span className={styles.league}>{gameday.league_display}</span>
         </div>
@@ -63,10 +65,10 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
         </span>
       </div>
 
-      {isLive && isActuallyLive && <ProgressBar total={stats.total} played={stats.played} live={stats.live} />}
+      {showProgressBar && <ProgressBar total={stats.total} played={stats.played} live={stats.live} />}
 
       <div className={styles.cardStats}>
-        {gameday.minutesUntilStart === undefined && stats.played === 0 && stats.live === 0 ? (
+        {showScheduledOnly ? (
           <span>{t('ui:gameProgress.card.gamesScheduled', { count: stats.total })}</span>
         ) : (
           <>
@@ -81,7 +83,7 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
             )}
           </>
         )}
-        {isLive && isActuallyLive && <span className={styles.percentComplete}>{stats.percentComplete}%</span>}
+        {showProgressBar && <span className={styles.percentComplete}>{stats.percentComplete}%</span>}
       </div>
     </a>
   );

--- a/journey_dashboard/src/components/game-progress/GamedayCard.tsx
+++ b/journey_dashboard/src/components/game-progress/GamedayCard.tsx
@@ -22,11 +22,19 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
   const endTime = lastGameTime ? addHours(lastGameTime, 2) : (gameday.start ? addHours(gameday.start, 2) : '');
   const gamedayUrl = `/gamedays/gameday/${gameday.id}/`;
 
+  const isActuallyLive = stats.played > 0 || stats.live > 0;
+
   return (
     <a href={gamedayUrl} className={`${styles.gamedayCard} ${isLive ? styles.cardLive : ''}`} style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
       <div className={styles.cardTop}>
         <div className={styles.cardHeader}>
-          {isLive && <span className={styles.liveBadge}>● LIVE</span>}
+          {isLive && (
+            isActuallyLive ? (
+              <span className={styles.liveBadge}>● LIVE</span>
+            ) : (
+              <span className={styles.upcomingBadgeToday}>● {t('ui:gameProgress.card.upcomingBadge')}</span>
+            )
+          )}
           {gameday.isStale ? (
             <span className={`${styles.timeUntil} ${styles.stale}`}>{t('ui:gameProgress.card.stale')}</span>
           ) : (
@@ -55,7 +63,7 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
         </span>
       </div>
 
-      {isLive && <ProgressBar total={stats.total} played={stats.played} live={stats.live} />}
+      {isLive && isActuallyLive && <ProgressBar total={stats.total} played={stats.played} live={stats.live} />}
 
       <div className={styles.cardStats}>
         {gameday.minutesUntilStart === undefined && stats.played === 0 && stats.live === 0 ? (
@@ -73,7 +81,7 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
             )}
           </>
         )}
-        {isLive && <span className={styles.percentComplete}>{stats.percentComplete}%</span>}
+        {isLive && isActuallyLive && <span className={styles.percentComplete}>{stats.percentComplete}%</span>}
       </div>
     </a>
   );

--- a/journey_dashboard/src/components/game-progress/GamedayCard.tsx
+++ b/journey_dashboard/src/components/game-progress/GamedayCard.tsx
@@ -22,9 +22,10 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
   const endTime = lastGameTime ? addHours(lastGameTime, 2) : (gameday.start ? addHours(gameday.start, 2) : '');
   const gamedayUrl = `/gamedays/gameday/${gameday.id}/`;
 
-  const isActuallyLive = stats.played > 0 || stats.live > 0;
-  const showProgressBar = isLive && isActuallyLive;
-  const showMinutesUntilStart = !gameday.isStale && gameday.minutesUntilStart !== undefined;
+  const isActuallyLive = stats.live > 0 || (stats.played > 0 && stats.pending > 0);
+  const isFinished = stats.played === stats.total && stats.total > 0;
+  const showProgressBar = (isActuallyLive || isFinished) && !gameday.isStale;
+  const showMinutesUntilStart = !gameday.isStale && gameday.minutesUntilStart !== undefined && !isActuallyLive && !isFinished;
   const showScheduledOnly = gameday.minutesUntilStart === undefined && stats.played === 0 && stats.live === 0;
 
   return (
@@ -34,6 +35,8 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
           {isLive && (
             isActuallyLive ? (
               <span className={styles.liveBadge}>● LIVE</span>
+            ) : isFinished ? (
+              <span className={styles.liveBadge}>● {t('ui:gameProgress.card.finishedBadge')}</span>
             ) : (
               <span className={styles.upcomingBadgeToday}>● {t('ui:gameProgress.card.upcomingBadge')}</span>
             )

--- a/journey_dashboard/src/components/game-progress/GamedayCard.tsx
+++ b/journey_dashboard/src/components/game-progress/GamedayCard.tsx
@@ -22,11 +22,24 @@ const GamedayCard: React.FC<GamedayCardProps> = ({ gameday, isLive = false }) =>
   const endTime = lastGameTime ? addHours(lastGameTime, 2) : (gameday.start ? addHours(gameday.start, 2) : '');
   const gamedayUrl = `/gamedays/gameday/${gameday.id}/`;
 
-  const isActuallyLive = stats.live > 0 || (stats.played > 0 && stats.pending > 0);
-  const isFinished = stats.played === stats.total && stats.total > 0;
-  const showProgressBar = (isActuallyLive || isFinished) && !gameday.isStale;
-  const showMinutesUntilStart = !gameday.isStale && gameday.minutesUntilStart !== undefined && !isActuallyLive && !isFinished;
-  const showScheduledOnly = gameday.minutesUntilStart === undefined && stats.played === 0 && stats.live === 0;
+  const hasGamesInProgress = stats.live > 0;
+  const hasGamesPlayedButPending = stats.played > 0 && stats.pending > 0;
+  const isActuallyLive = hasGamesInProgress || hasGamesPlayedButPending;
+
+  const hasGames = stats.total > 0;
+  const allGamesCompleted = stats.played === stats.total;
+  const isFinished = hasGames && allGamesCompleted;
+
+  const isNotStale = !gameday.isStale;
+  const hasMinutesUntilStart = gameday.minutesUntilStart !== undefined;
+  const showProgressBar = (isActuallyLive || isFinished) && isNotStale;
+  const shouldShowMinutes = isNotStale && hasMinutesUntilStart && !isActuallyLive && !isFinished;
+  const showMinutesUntilStart = shouldShowMinutes;
+
+  const noMinutesAvailable = gameday.minutesUntilStart === undefined;
+  const noGamesPlayed = stats.played === 0;
+  const noGamesLive = stats.live === 0;
+  const showScheduledOnly = noMinutesAvailable && noGamesPlayed && noGamesLive;
 
   return (
     <a href={gamedayUrl} className={`${styles.gamedayCard} ${isLive ? styles.cardLive : ''}`} style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>

--- a/journey_dashboard/src/components/game-progress/ProgressBar.tsx
+++ b/journey_dashboard/src/components/game-progress/ProgressBar.tsx
@@ -8,19 +8,22 @@ interface ProgressBarProps {
 }
 
 const ProgressBar: React.FC<ProgressBarProps> = ({ total, played, live }) => {
+  const isFinished = played === total && total > 0;
   const playedPercentage = total > 0 ? (played / total) * 100 : 0;
   const livePercentage = total > 0 ? (live / total) * 100 : 0;
   const pendingPercentage = total > 0 ? ((total - played - live) / total) * 100 : 0;
 
+  const playedColor = isFinished ? '#28a745' : '#6c757d';
+
   return (
     <div className={styles.progressBar}>
-      {/* Played games (blue) */}
+      {/* Played games (gray or green if finished) */}
       {playedPercentage > 0 && (
         <div
           className={styles.progressSegment}
           style={{
             width: `${playedPercentage}%`,
-            backgroundColor: '#6c757d',
+            backgroundColor: playedColor,
           }}
         />
       )}

--- a/journey_dashboard/src/components/game-progress/__tests__/GameProgressPage.test.tsx
+++ b/journey_dashboard/src/components/game-progress/__tests__/GameProgressPage.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GameProgressPage from '../GameProgressPage';
+import { useGameProgress } from '../hooks/useGameProgress';
+
+vi.mock('../hooks/useGameProgress');
+vi.mock('../../../i18n/useTypedTranslation', () => ({
+  useTypedTranslation: () => ({
+    t: (key: string, params?: any) => {
+      if (key === 'ui:gameProgress.section.live') return `Live (${params.count} Games)`;
+      if (key === 'ui:gameProgress.section.today_top') return 'Today';
+      if (key === 'ui:gameProgress.section.today_results') return `Results (${params.count} Gamedays)`;
+      if (key === 'ui:gameProgress.section.outlook') return 'Outlook';
+      return key;
+    },
+  }),
+}));
+
+// Mock GamedayCard to avoid deep rendering issues in this test
+vi.mock('../GamedayCard', () => ({
+  default: ({ gameday }: any) => <div data-testid="gameday-card">{gameday.name}</div>
+}));
+
+describe('GameProgressPage', () => {
+  const baseState = {
+    loading: false,
+    error: null,
+    gamedays: [],
+    live: [],
+    soon: [],
+    today: [],
+    recent: [],
+    upcoming: [],
+    totalLiveGames: 0,
+    totalPlayedGamesToday: 0,
+    todayGamedayCount: 0,
+  };
+
+  it('should show "Today" header when gamedays exist but none are live or played', () => {
+    vi.mocked(useGameProgress).mockReturnValue({
+      ...baseState,
+      gamedays: [{ id: 1 } as any],
+      live: [{ id: 1, name: 'Upcoming Today' } as any],
+    } as any);
+
+    render(<GameProgressPage />);
+    expect(screen.getByText('Today')).toBeDefined();
+  });
+
+  it('should show "Live" header when games are actually in progress', () => {
+    vi.mocked(useGameProgress).mockReturnValue({
+      ...baseState,
+      gamedays: [{ id: 1 } as any],
+      live: [{ id: 1, name: 'Live Gameday' } as any],
+      totalLiveGames: 3,
+    } as any);
+
+    render(<GameProgressPage />);
+    expect(screen.getByText('Live (3 Games)')).toBeDefined();
+  });
+
+  it('should show "Results" header when games are finished but none are live', () => {
+    vi.mocked(useGameProgress).mockReturnValue({
+      ...baseState,
+      gamedays: [{ id: 1 } as any],
+      live: [{ id: 1, name: 'Finished Today' } as any],
+      totalPlayedGamesToday: 10,
+    } as any);
+
+    render(<GameProgressPage />);
+    expect(screen.getByText('Results (1 Gamedays)')).toBeDefined();
+  });
+});

--- a/journey_dashboard/src/components/game-progress/__tests__/GameProgressPage.test.tsx
+++ b/journey_dashboard/src/components/game-progress/__tests__/GameProgressPage.test.tsx
@@ -3,13 +3,15 @@ import { render, screen } from '@testing-library/react';
 import GameProgressPage from '../GameProgressPage';
 import { useGameProgress } from '../hooks/useGameProgress';
 
+import { GameProgressState } from '../../../types/progressTypes';
+
 vi.mock('../hooks/useGameProgress');
 vi.mock('../../../i18n/useTypedTranslation', () => ({
   useTypedTranslation: () => ({
-    t: (key: string, params?: any) => {
-      if (key === 'ui:gameProgress.section.live') return `Live (${params.count} Games)`;
+    t: (key: string, params?: Record<string, string | number>) => {
+      if (key === 'ui:gameProgress.section.live') return `Live (${params?.count} Games)`;
       if (key === 'ui:gameProgress.section.today_top') return 'Today';
-      if (key === 'ui:gameProgress.section.today_results') return `Results (${params.count} Gamedays)`;
+      if (key === 'ui:gameProgress.section.today_results') return `Results (${params?.count} Gamedays)`;
       if (key === 'ui:gameProgress.section.outlook') return 'Outlook';
       return key;
     },
@@ -18,11 +20,11 @@ vi.mock('../../../i18n/useTypedTranslation', () => ({
 
 // Mock GamedayCard to avoid deep rendering issues in this test
 vi.mock('../GamedayCard', () => ({
-  default: ({ gameday }: any) => <div data-testid="gameday-card">{gameday.name}</div>
+  default: ({ gameday }: { gameday: { name: string } }) => <div data-testid="gameday-card">{gameday.name}</div>
 }));
 
 describe('GameProgressPage', () => {
-  const baseState = {
+  const baseState: GameProgressState = {
     loading: false,
     error: null,
     gamedays: [],
@@ -39,9 +41,9 @@ describe('GameProgressPage', () => {
   it('should show "Today" header when gamedays exist but none are live or played', () => {
     vi.mocked(useGameProgress).mockReturnValue({
       ...baseState,
-      gamedays: [{ id: 1 } as any],
-      live: [{ id: 1, name: 'Upcoming Today' } as any],
-    } as any);
+      gamedays: [{ id: 1 }] as unknown as GameProgressState['gamedays'],
+      live: [{ id: 1, name: 'Upcoming Today' }] as unknown as GameProgressState['live'],
+    } as GameProgressState);
 
     render(<GameProgressPage />);
     expect(screen.getByText('Today')).toBeDefined();
@@ -50,10 +52,10 @@ describe('GameProgressPage', () => {
   it('should show "Live" header when games are actually in progress', () => {
     vi.mocked(useGameProgress).mockReturnValue({
       ...baseState,
-      gamedays: [{ id: 1 } as any],
-      live: [{ id: 1, name: 'Live Gameday' } as any],
+      gamedays: [{ id: 1 }] as unknown as GameProgressState['gamedays'],
+      live: [{ id: 1, name: 'Live Gameday' }] as unknown as GameProgressState['live'],
       totalLiveGames: 3,
-    } as any);
+    } as GameProgressState);
 
     render(<GameProgressPage />);
     expect(screen.getByText('Live (3 Games)')).toBeDefined();
@@ -62,10 +64,10 @@ describe('GameProgressPage', () => {
   it('should show "Results" header when games are finished but none are live', () => {
     vi.mocked(useGameProgress).mockReturnValue({
       ...baseState,
-      gamedays: [{ id: 1 } as any],
-      live: [{ id: 1, name: 'Finished Today' } as any],
+      gamedays: [{ id: 1 }] as unknown as GameProgressState['gamedays'],
+      live: [{ id: 1, name: 'Finished Today' }] as unknown as GameProgressState['live'],
       totalPlayedGamesToday: 10,
-    } as any);
+    } as GameProgressState);
 
     render(<GameProgressPage />);
     expect(screen.getByText('Results (1 Gamedays)')).toBeDefined();

--- a/journey_dashboard/src/components/game-progress/__tests__/GamedayCard.test.tsx
+++ b/journey_dashboard/src/components/game-progress/__tests__/GamedayCard.test.tsx
@@ -1,23 +1,23 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import GamedayCard from '../GamedayCard';
-import { GameStatus } from '../../../types/progressTypes';
+import { GamedayWithStats } from '../../../types/progressTypes';
 
 // Mock translation
 vi.mock('../../../i18n/useTypedTranslation', () => ({
   useTypedTranslation: () => ({
-    t: (key: string, params?: any) => {
+    t: (key: string, params?: Record<string, string | number>) => {
       if (key === 'ui:gameProgress.card.upcomingBadge') return 'UPCOMING';
       if (key === 'ui:gameProgress.card.finishedBadge') return 'FINISHED';
-      if (key === 'ui:gameProgress.card.minutesUntil') return `${params.minutes} min until start`;
-      if (key === 'ui:gameProgress.card.played') return `Played ${params.played}/${params.total}`;
+      if (key === 'ui:gameProgress.card.minutesUntil') return `${params?.minutes} min until start`;
+      if (key === 'ui:gameProgress.card.played') return `Played ${params?.played}/${params?.total}`;
       return key;
     },
   }),
 }));
 
 describe('GamedayCard', () => {
-  const baseGameday = {
+  const baseGameday: Partial<GamedayWithStats> = {
     id: 1,
     name: 'Test Gameday',
     date: '2026-05-24',
@@ -32,7 +32,7 @@ describe('GamedayCard', () => {
       ...baseGameday,
       minutesUntilStart: 60,
     };
-    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    render(<GamedayCard gameday={gameday as GamedayWithStats} isLive={true} />);
     
     expect(screen.getByText(/UPCOMING/)).toBeDefined();
     expect(screen.getByText('60 min until start')).toBeDefined();
@@ -45,7 +45,7 @@ describe('GamedayCard', () => {
       ...baseGameday,
       stats: { total: 10, played: 2, live: 1, pending: 7, percentComplete: 20 }
     };
-    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    render(<GamedayCard gameday={gameday as GamedayWithStats} isLive={true} />);
     
     expect(screen.getByText(/LIVE/)).toBeDefined();
     expect(screen.getByText('Played 2/10')).toBeDefined();
@@ -57,7 +57,7 @@ describe('GamedayCard', () => {
       ...baseGameday,
       stats: { total: 10, played: 10, live: 0, pending: 0, percentComplete: 100 }
     };
-    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    render(<GamedayCard gameday={gameday as GamedayWithStats} isLive={true} />);
     
     expect(screen.getByText(/FINISHED/)).toBeDefined();
     expect(screen.getByText('Played 10/10')).toBeDefined();
@@ -69,7 +69,7 @@ describe('GamedayCard', () => {
       ...baseGameday,
       isStale: true,
     };
-    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    render(<GamedayCard gameday={gameday as GamedayWithStats} isLive={true} />);
     
     expect(screen.getByText('ui:gameProgress.card.stale')).toBeDefined();
     // Minutes until start should be hidden if stale

--- a/journey_dashboard/src/components/game-progress/__tests__/GamedayCard.test.tsx
+++ b/journey_dashboard/src/components/game-progress/__tests__/GamedayCard.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GamedayCard from '../GamedayCard';
+import { GameStatus } from '../../../types/progressTypes';
+
+// Mock translation
+vi.mock('../../../i18n/useTypedTranslation', () => ({
+  useTypedTranslation: () => ({
+    t: (key: string, params?: any) => {
+      if (key === 'ui:gameProgress.card.upcomingBadge') return 'UPCOMING';
+      if (key === 'ui:gameProgress.card.finishedBadge') return 'FINISHED';
+      if (key === 'ui:gameProgress.card.minutesUntil') return `${params.minutes} min until start`;
+      if (key === 'ui:gameProgress.card.played') return `Played ${params.played}/${params.total}`;
+      return key;
+    },
+  }),
+}));
+
+describe('GamedayCard', () => {
+  const baseGameday = {
+    id: 1,
+    name: 'Test Gameday',
+    date: '2026-05-24',
+    start: '10:00:00',
+    league_display: 'Test League',
+    games: [],
+    stats: { total: 10, played: 0, live: 0, pending: 10, percentComplete: 0 }
+  };
+
+  it('should show UPCOMING badge when today gameday has not started', () => {
+    const gameday = {
+      ...baseGameday,
+      minutesUntilStart: 60,
+    };
+    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    
+    expect(screen.getByText(/UPCOMING/)).toBeDefined();
+    expect(screen.getByText('60 min until start')).toBeDefined();
+    // Progress bar should be hidden
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
+  it('should show LIVE badge when today gameday has live games', () => {
+    const gameday = {
+      ...baseGameday,
+      stats: { total: 10, played: 2, live: 1, pending: 7, percentComplete: 20 }
+    };
+    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    
+    expect(screen.getByText(/LIVE/)).toBeDefined();
+    expect(screen.getByText('Played 2/10')).toBeDefined();
+    expect(screen.getByText('20%')).toBeDefined();
+  });
+
+  it('should show FINISHED badge when today gameday is complete', () => {
+    const gameday = {
+      ...baseGameday,
+      stats: { total: 10, played: 10, live: 0, pending: 0, percentComplete: 100 }
+    };
+    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    
+    expect(screen.getByText(/FINISHED/)).toBeDefined();
+    expect(screen.getByText('Played 10/10')).toBeDefined();
+    expect(screen.getByText('100%')).toBeDefined();
+  });
+
+  it('should show stale label if gameday is stale', () => {
+    const gameday = {
+      ...baseGameday,
+      isStale: true,
+    };
+    render(<GamedayCard gameday={gameday as any} isLive={true} />);
+    
+    expect(screen.getByText('ui:gameProgress.card.stale')).toBeDefined();
+    // Minutes until start should be hidden if stale
+    expect(screen.queryByText(/min until start/)).toBeNull();
+  });
+});

--- a/journey_dashboard/src/components/game-progress/__tests__/ProgressBar.test.tsx
+++ b/journey_dashboard/src/components/game-progress/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ProgressBar from '../ProgressBar';
+import styles from '../styles.module.css';
+
+describe('ProgressBar', () => {
+  it('should use gray color for played games when not finished', () => {
+    const { container } = render(<ProgressBar total={10} played={5} live={2} />);
+    const playedSegment = container.querySelector(`.${styles.progressSegment}`);
+    expect(playedSegment).toHaveStyle({ backgroundColor: '#6c757d' });
+  });
+
+  it('should use green color for played games when finished', () => {
+    const { container } = render(<ProgressBar total={10} played={10} live={0} />);
+    const playedSegment = container.querySelector(`.${styles.progressSegment}`);
+    expect(playedSegment).toHaveStyle({ backgroundColor: '#28a745' });
+  });
+
+  it('should not render played segment if played is 0', () => {
+    const { container } = render(<ProgressBar total={10} played={0} live={2} />);
+    // The first segment will be live (green)
+    const playedSegment = container.querySelector(`[style*="background-color: rgb(108, 117, 125)"]`); // #6c757d
+    expect(playedSegment).toBeNull();
+  });
+});

--- a/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
+++ b/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useGameProgress } from '../hooks/useGameProgress';
+import { GamedayProgress, GameStatus } from '../../../types/progressTypes';
 import { progressApi } from '../../../api/progressApi';
-import { GameStatus } from '../../../types/progressTypes';
 
-vi.mock('../../../api/progressApi', () => ({
-  progressApi: {
-    list: vi.fn(),
-  },
-}));
+vi.mock('../../../api/progressApi');
 
 describe('useGameProgress', () => {
   const mockNow = new Date('2026-05-24T12:00:00');
@@ -24,18 +20,17 @@ describe('useGameProgress', () => {
   });
 
   it('should categorize a today ongoing gameday as live and calculate minutes until start', async () => {
-    const mockGameday = {
+    const mockGameday: Partial<GamedayProgress> = {
       id: 1,
       name: 'Today Gameday',
       date: '2026-05-24',
       start: '14:00:00',
       games: [
-        { id: 101, status: GameStatus.PLANNED, scheduled: '14:00:00' }
+        { id: 101, status: GameStatus.PLANNED, scheduled: '14:00:00', field: 1, gameStarted: null, gameFinished: null, gameresult: null }
       ],
-      stats: { total: 1, played: 0, live: 0, pending: 1, percentComplete: 0 }
     };
 
-    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as any]);
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as GamedayProgress]);
 
     const { result } = renderHook(() => useGameProgress());
 
@@ -50,18 +45,17 @@ describe('useGameProgress', () => {
   });
 
   it('should not mark a finished gameday as stale even if time has passed', async () => {
-    const mockGameday = {
+    const mockGameday: Partial<GamedayProgress> = {
       id: 2,
       name: 'Finished Today',
       date: '2026-05-24',
       start: '08:00:00',
       games: [
-        { id: 201, status: GameStatus.COMPLETED, scheduled: '08:00:00' }
+        { id: 201, status: GameStatus.COMPLETED, scheduled: '08:00:00', field: 1, gameStarted: '08:00:00', gameFinished: '09:00:00', gameresult: null }
       ],
-      stats: { total: 1, played: 1, live: 0, pending: 0, percentComplete: 100 }
     };
 
-    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as any]);
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as GamedayProgress]);
 
     const { result } = renderHook(() => useGameProgress());
 
@@ -74,18 +68,17 @@ describe('useGameProgress', () => {
 
   it('should mark an unstarted gameday as stale if it is long past its end time', async () => {
     // End time is start + 2h = 10:00. Now is 12:00.
-    const mockGameday = {
+    const mockGameday: Partial<GamedayProgress> = {
       id: 3,
       name: 'Stale Today',
       date: '2026-05-24',
       start: '08:00:00',
       games: [
-        { id: 301, status: GameStatus.PLANNED, scheduled: '08:00:00' }
+        { id: 301, status: GameStatus.PLANNED, scheduled: '08:00:00', field: 1, gameStarted: null, gameFinished: null, gameresult: null }
       ],
-      stats: { total: 1, played: 0, live: 0, pending: 1, percentComplete: 0 }
     };
 
-    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as any]);
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as GamedayProgress]);
 
     const { result } = renderHook(() => useGameProgress());
 
@@ -97,26 +90,30 @@ describe('useGameProgress', () => {
   });
 
   it('should calculate totalPlayedGamesToday correctly', async () => {
-    const mockGamedays = [
+    const mockGamedays: Partial<GamedayProgress>[] = [
       {
         id: 1,
         date: '2026-05-24',
         name: 'G1',
         start: '12:00:00',
-        games: [{ status: GameStatus.COMPLETED }, { status: GameStatus.COMPLETED }],
-        stats: { total: 2, played: 2, live: 0, pending: 0 }
+        games: [
+          { status: GameStatus.COMPLETED, id: 1 },
+          { status: GameStatus.COMPLETED, id: 2 }
+        ] as unknown as GamedayProgress['games'],
       },
       {
         id: 2,
         date: '2026-05-24',
         name: 'G2',
         start: '12:00:00',
-        games: [{ status: GameStatus.COMPLETED }, { status: GameStatus.IN_PROGRESS }],
-        stats: { total: 2, played: 1, live: 1, pending: 0 }
+        games: [
+          { status: GameStatus.COMPLETED, id: 3 },
+          { status: GameStatus.IN_PROGRESS, id: 4 }
+        ] as unknown as GamedayProgress['games'],
       }
     ];
 
-    vi.mocked(progressApi.list).mockResolvedValue(mockGamedays as any);
+    vi.mocked(progressApi.list).mockResolvedValue(mockGamedays as GamedayProgress[]);
 
     const { result } = renderHook(() => useGameProgress());
 

--- a/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
+++ b/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useGameProgress } from '../hooks/useGameProgress';
+import { progressApi } from '../../../api/progressApi';
+import { GameStatus } from '../../../types/progressTypes';
+
+vi.mock('../../../api/progressApi', () => ({
+  progressApi: {
+    list: vi.fn(),
+  },
+}));
+
+describe('useGameProgress', () => {
+  const mockNow = new Date('2026-05-24T12:00:00');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should categorize a today ongoing gameday as live and calculate minutes until start', async () => {
+    const mockGameday = {
+      id: 1,
+      name: 'Today Gameday',
+      date: '2026-05-24',
+      start: '14:00:00',
+      games: [
+        { id: 101, status: GameStatus.PLANNED, scheduled: '14:00:00' }
+      ],
+      stats: { total: 1, played: 0, live: 0, pending: 1, percentComplete: 0 }
+    };
+
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as any]);
+
+    const { result } = renderHook(() => useGameProgress());
+
+    // Use vi.waitFor instead of @testing-library/react's waitFor when using fake timers
+    await vi.waitFor(() => expect(result.current.loading).toBe(false), { timeout: 1000 });
+
+    expect(result.current.live).toHaveLength(1);
+    // Allow for small timing variations if any, but 120 is expected
+    expect(result.current.live[0].minutesUntilStart).toBeGreaterThanOrEqual(119);
+    expect(result.current.live[0].minutesUntilStart).toBeLessThanOrEqual(120);
+    expect(result.current.live[0].isStale).toBe(false);
+  });
+
+  it('should not mark a finished gameday as stale even if time has passed', async () => {
+    const mockGameday = {
+      id: 2,
+      name: 'Finished Today',
+      date: '2026-05-24',
+      start: '08:00:00',
+      games: [
+        { id: 201, status: GameStatus.COMPLETED, scheduled: '08:00:00' }
+      ],
+      stats: { total: 1, played: 1, live: 0, pending: 0, percentComplete: 100 }
+    };
+
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as any]);
+
+    const { result } = renderHook(() => useGameProgress());
+
+    await vi.waitFor(() => expect(result.current.loading).toBe(false), { timeout: 1000 });
+
+    expect(result.current.live).toHaveLength(1);
+    expect(result.current.live[0].isStale).toBe(false);
+    expect(result.current.today).toHaveLength(0);
+  });
+
+  it('should mark an unstarted gameday as stale if it is long past its end time', async () => {
+    // End time is start + 2h = 10:00. Now is 12:00.
+    const mockGameday = {
+      id: 3,
+      name: 'Stale Today',
+      date: '2026-05-24',
+      start: '08:00:00',
+      games: [
+        { id: 301, status: GameStatus.PLANNED, scheduled: '08:00:00' }
+      ],
+      stats: { total: 1, played: 0, live: 0, pending: 1, percentComplete: 0 }
+    };
+
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as any]);
+
+    const { result } = renderHook(() => useGameProgress());
+
+    await vi.waitFor(() => expect(result.current.loading).toBe(false), { timeout: 1000 });
+
+    expect(result.current.live).toHaveLength(0);
+    expect(result.current.today).toHaveLength(1);
+    expect(result.current.today[0].isStale).toBe(true);
+  });
+
+  it('should calculate totalPlayedGamesToday correctly', async () => {
+    const mockGamedays = [
+      {
+        id: 1,
+        date: '2026-05-24',
+        name: 'G1',
+        start: '12:00:00',
+        games: [{ status: GameStatus.COMPLETED }, { status: GameStatus.COMPLETED }],
+        stats: { total: 2, played: 2, live: 0, pending: 0 }
+      },
+      {
+        id: 2,
+        date: '2026-05-24',
+        name: 'G2',
+        start: '12:00:00',
+        games: [{ status: GameStatus.COMPLETED }, { status: GameStatus.IN_PROGRESS }],
+        stats: { total: 2, played: 1, live: 1, pending: 0 }
+      }
+    ];
+
+    vi.mocked(progressApi.list).mockResolvedValue(mockGamedays as any);
+
+    const { result } = renderHook(() => useGameProgress());
+
+    await vi.waitFor(() => expect(result.current.loading).toBe(false), { timeout: 1000 });
+
+    expect(result.current.totalPlayedGamesToday).toBe(3);
+  });
+});

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -71,17 +71,9 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
     const isFinished = isGamedayFinished(gamedayWithStats.stats);
     const gamedayEndTime = calculateGamedayEndTime(gameday.date, gameday.games);
     const now = new Date();
-    const isOngoing = !isFinished && now < gamedayEndTime;
     const isToday = gamedayDate.getTime() === today.getTime();
 
-    if (isToday && isOngoing) {
-      const withMinutes = {
-        ...gamedayWithStats,
-        minutesUntilStart: calculateMinutesUntilStart(gameday.date, gameday.start),
-      };
-      live.push(withMinutes);
-      totalLiveGames += gamedayWithStats.stats.live;
-    } else if (isToday) {
+    if (isToday) {
       const endTimePlusThreeHours = new Date(gamedayEndTime.getTime() + 3 * 60 * 60 * 1000);
       const noGamesStarted = gamedayWithStats.stats.played === 0 && gamedayWithStats.stats.live === 0;
       const someGamesStarted = !noGamesStarted;
@@ -89,14 +81,20 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
 
       const isOverByTimeAndNoStart = now > gamedayEndTime && noGamesStarted;
       const isOverByLongTimeAndSomeStart = now > endTimePlusThreeHours && someGamesStarted;
-      const isStale = noGamesAtAll || isOverByTimeAndNoStart || isOverByLongTimeAndSomeStart;
+      const isStale = !isFinished && (noGamesAtAll || isOverByTimeAndNoStart || isOverByLongTimeAndSomeStart);
 
       const withMinutes = {
         ...gamedayWithStats,
         minutesUntilStart: calculateMinutesUntilStart(gameday.date, gameday.start),
         isStale,
       };
-      todayGamedays.push(withMinutes);
+
+      if (!isStale) {
+        live.push(withMinutes);
+        totalLiveGames += gamedayWithStats.stats.live;
+      } else {
+        todayGamedays.push(withMinutes);
+      }
     } else if (gamedayDate > today) {
       const daysFromNow = Math.ceil((gamedayDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
       if (daysFromNow <= 7) {

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -62,6 +62,7 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
   const upcoming: GamedayWithStats[] = [];
 
   let totalLiveGames = 0;
+  let totalPlayedGamesToday = 0;
 
   gamedays.forEach((gameday) => {
     const gamedayWithStats = addStats(gameday);
@@ -92,6 +93,7 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
       if (!isStale) {
         live.push(withMinutes);
         totalLiveGames += gamedayWithStats.stats.live;
+        totalPlayedGamesToday += gamedayWithStats.stats.played;
       } else {
         todayGamedays.push(withMinutes);
       }
@@ -114,6 +116,7 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
     recent,
     upcoming,
     totalLiveGames,
+    totalPlayedGamesToday,
     todayGamedayCount: todayGamedays.length,
   };
 }

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -82,12 +82,15 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
       live.push(withMinutes);
       totalLiveGames += gamedayWithStats.stats.live;
     } else if (isToday) {
-      const gamedayEndTime = calculateGamedayEndTime(gameday.date, gameday.games);
       const endTimePlusThreeHours = new Date(gamedayEndTime.getTime() + 3 * 60 * 60 * 1000);
       const noGamesStarted = gamedayWithStats.stats.played === 0 && gamedayWithStats.stats.live === 0;
-      const someGamesStarted = gamedayWithStats.stats.played > 0 || gamedayWithStats.stats.live > 0;
+      const someGamesStarted = !noGamesStarted;
       const noGamesAtAll = gamedayWithStats.stats.total === 0;
-      const isStale = noGamesAtAll || (now > gamedayEndTime && noGamesStarted) || (now > endTimePlusThreeHours && someGamesStarted);
+
+      const isOverByTimeAndNoStart = now > gamedayEndTime && noGamesStarted;
+      const isOverByLongTimeAndSomeStart = now > endTimePlusThreeHours && someGamesStarted;
+      const isStale = noGamesAtAll || isOverByTimeAndNoStart || isOverByLongTimeAndSomeStart;
+
       const withMinutes = {
         ...gamedayWithStats,
         minutesUntilStart: calculateMinutesUntilStart(gameday.date, gameday.start),

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -45,7 +45,28 @@ function calculateGamedayEndTime(dateStr: string, games: GamedayProgress['games'
 }
 
 function isGamedayFinished(stats: GamedayStats): boolean {
-  return stats.pending === 0 && stats.live === 0;
+  const allGamesPending = stats.pending === 0;
+  const noGamesInProgress = stats.live === 0;
+  return allGamesPending && noGamesInProgress;
+}
+
+function isTodayGamedayStale(
+  stats: GamedayStats,
+  isFinished: boolean,
+  now: Date,
+  gamedayEndTime: Date,
+): boolean {
+  const endTimePlusThreeHours = new Date(gamedayEndTime.getTime() + 3 * 60 * 60 * 1000);
+
+  const noGamesStarted = stats.played === 0 && stats.live === 0;
+  const someGamesStarted = !noGamesStarted;
+  const noGamesAtAll = stats.total === 0;
+
+  const isOverByTimeAndNoStart = now > gamedayEndTime && noGamesStarted;
+  const isOverByLongTimeAndSomeStart = now > endTimePlusThreeHours && someGamesStarted;
+
+  const shouldBeStaleBecauseNoProgress = noGamesAtAll || isOverByTimeAndNoStart || isOverByLongTimeAndSomeStart;
+  return !isFinished && shouldBeStaleBecauseNoProgress;
 }
 
 function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState, 'loading' | 'error' | 'gamedays'> {
@@ -75,14 +96,7 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
     const isToday = gamedayDate.getTime() === today.getTime();
 
     if (isToday) {
-      const endTimePlusThreeHours = new Date(gamedayEndTime.getTime() + 3 * 60 * 60 * 1000);
-      const noGamesStarted = gamedayWithStats.stats.played === 0 && gamedayWithStats.stats.live === 0;
-      const someGamesStarted = !noGamesStarted;
-      const noGamesAtAll = gamedayWithStats.stats.total === 0;
-
-      const isOverByTimeAndNoStart = now > gamedayEndTime && noGamesStarted;
-      const isOverByLongTimeAndSomeStart = now > endTimePlusThreeHours && someGamesStarted;
-      const isStale = !isFinished && (noGamesAtAll || isOverByTimeAndNoStart || isOverByLongTimeAndSomeStart);
+      const isStale = isTodayGamedayStale(gamedayWithStats.stats, isFinished, now, gamedayEndTime);
 
       const withMinutes = {
         ...gamedayWithStats,

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -75,7 +75,11 @@ function categorizeGamedays(gamedays: GamedayProgress[]): Omit<GameProgressState
     const isToday = gamedayDate.getTime() === today.getTime();
 
     if (isToday && isOngoing) {
-      live.push(gamedayWithStats);
+      const withMinutes = {
+        ...gamedayWithStats,
+        minutesUntilStart: calculateMinutesUntilStart(gameday.date, gameday.start),
+      };
+      live.push(withMinutes);
       totalLiveGames += gamedayWithStats.stats.live;
     } else if (isToday) {
       const gamedayEndTime = calculateGamedayEndTime(gameday.date, gameday.games);

--- a/journey_dashboard/src/components/game-progress/styles.module.css
+++ b/journey_dashboard/src/components/game-progress/styles.module.css
@@ -86,6 +86,15 @@
   font-size: 0.75rem;
 }
 
+.upcomingBadgeToday {
+  background-color: #ff9500;
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
 .timeUntil {
   font-weight: 600;
   color: #ff9500;

--- a/journey_dashboard/src/i18n/locales/de/ui.json
+++ b/journey_dashboard/src/i18n/locales/de/ui.json
@@ -233,7 +233,8 @@
       "gamesScheduled": "Spiele geplant",
       "live": "Live",
       "upcomingBadge": "ANSTEHEND",
-      "played": "Gespielt",
+      "finishedBadge": "BEENDET",
+      "played": "Gespielt {{played}}/{{total}}",
       "pending": "Anstehend",
       "stale": "Abgelaufen",
       "minutesUntil": "{{minutes}} Min bis zum Start"

--- a/journey_dashboard/src/i18n/locales/de/ui.json
+++ b/journey_dashboard/src/i18n/locales/de/ui.json
@@ -224,10 +224,11 @@
     },
     "section": {
       "live": "Live ({{count}} Spiele)",
-      "today": "Heute ({{count}} Spiele)",
-      "today_top": "Heute",
-      "outlook": "Ausblick (nächste {{days}} Tage, {{count}} Spiele)",
-      "recent": "Rückblick ({{count}} Spiele)"
+      "today": "Heute ({{count}} Spieltage)",
+      "today_top": "Heute ({{count}} Spieltage)",
+      "today_results": "Ergebnisse ({{count}} Spieltage)",
+      "outlook": "Ausblick (nächste {{days}} Tage, {{count}} Spieltage)",
+      "recent": "Rückblick ({{count}} Spieltage)"
     },
     "card": {
       "gamesScheduled": "Spiele geplant",

--- a/journey_dashboard/src/i18n/locales/de/ui.json
+++ b/journey_dashboard/src/i18n/locales/de/ui.json
@@ -231,7 +231,7 @@
       "recent": "Rückblick ({{count}} Spieltage)"
     },
     "card": {
-      "gamesScheduled": "Spiele geplant",
+      "gamesScheduled": "Spiele geplant {{count}}",
       "live": "Live",
       "upcomingBadge": "ANSTEHEND",
       "finishedBadge": "BEENDET",

--- a/journey_dashboard/src/i18n/locales/de/ui.json
+++ b/journey_dashboard/src/i18n/locales/de/ui.json
@@ -231,12 +231,12 @@
       "recent": "Rückblick ({{count}} Spieltage)"
     },
     "card": {
-      "gamesScheduled": "Spiele geplant {{count}}",
-      "live": "Live",
+      "gamesScheduled": "{{count}} Spiele geplant",
+      "live": "{{count}} Spiele live",
       "upcomingBadge": "ANSTEHEND",
       "finishedBadge": "BEENDET",
       "played": "Gespielt {{played}}/{{total}}",
-      "pending": "Anstehend",
+      "pending": "{{count}} Spiele anstehend",
       "stale": "Abgelaufen",
       "minutesUntil": "{{minutes}} Min bis zum Start"
     }

--- a/journey_dashboard/src/i18n/locales/de/ui.json
+++ b/journey_dashboard/src/i18n/locales/de/ui.json
@@ -225,12 +225,14 @@
     "section": {
       "live": "Live ({{count}} Spiele)",
       "today": "Heute ({{count}} Spiele)",
+      "today_top": "Heute",
       "outlook": "Ausblick (nächste {{days}} Tage, {{count}} Spiele)",
       "recent": "Rückblick ({{count}} Spiele)"
     },
     "card": {
       "gamesScheduled": "Spiele geplant",
       "live": "Live",
+      "upcomingBadge": "ANSTEHEND",
       "played": "Gespielt",
       "pending": "Anstehend",
       "stale": "Abgelaufen",

--- a/journey_dashboard/src/i18n/locales/en/ui.json
+++ b/journey_dashboard/src/i18n/locales/en/ui.json
@@ -233,7 +233,8 @@
       "gamesScheduled": "Games scheduled",
       "live": "Live",
       "upcomingBadge": "UPCOMING",
-      "played": "Played",
+      "finishedBadge": "FINISHED",
+      "played": "Played {{played}}/{{total}}",
       "pending": "Pending",
       "stale": "Stale",
       "minutesUntil": "{{minutes}} min until start"

--- a/journey_dashboard/src/i18n/locales/en/ui.json
+++ b/journey_dashboard/src/i18n/locales/en/ui.json
@@ -231,7 +231,7 @@
       "recent": "Lookback ({{count}} gamedays)"
     },
     "card": {
-      "gamesScheduled": "Games scheduled",
+      "gamesScheduled": "Games scheduled {{count}}",
       "live": "Live",
       "upcomingBadge": "UPCOMING",
       "finishedBadge": "FINISHED",

--- a/journey_dashboard/src/i18n/locales/en/ui.json
+++ b/journey_dashboard/src/i18n/locales/en/ui.json
@@ -225,12 +225,14 @@
     "section": {
       "live": "Live ({{count}} games)",
       "today": "Today ({{count}} games)",
+      "today_top": "Today",
       "outlook": "Outlook (next {{days}} days, {{count}} games)",
       "recent": "Lookback ({{count}} games)"
     },
     "card": {
       "gamesScheduled": "Games scheduled",
       "live": "Live",
+      "upcomingBadge": "UPCOMING",
       "played": "Played",
       "pending": "Pending",
       "stale": "Stale",

--- a/journey_dashboard/src/i18n/locales/en/ui.json
+++ b/journey_dashboard/src/i18n/locales/en/ui.json
@@ -231,12 +231,12 @@
       "recent": "Lookback ({{count}} gamedays)"
     },
     "card": {
-      "gamesScheduled": "Games scheduled {{count}}",
-      "live": "Live",
+      "gamesScheduled": "{{count}} games planned",
+      "live": "{{count}} games live",
       "upcomingBadge": "UPCOMING",
       "finishedBadge": "FINISHED",
       "played": "Played {{played}}/{{total}}",
-      "pending": "Pending",
+      "pending": "{{count}} games pending",
       "stale": "Stale",
       "minutesUntil": "{{minutes}} min until start"
     }

--- a/journey_dashboard/src/i18n/locales/en/ui.json
+++ b/journey_dashboard/src/i18n/locales/en/ui.json
@@ -224,10 +224,11 @@
     },
     "section": {
       "live": "Live ({{count}} games)",
-      "today": "Today ({{count}} games)",
-      "today_top": "Today",
-      "outlook": "Outlook (next {{days}} days, {{count}} games)",
-      "recent": "Lookback ({{count}} games)"
+      "today": "Today ({{count}} gamedays)",
+      "today_top": "Today ({{count}} gamedays)",
+      "today_results": "Results ({{count}} gamedays)",
+      "outlook": "Outlook (next {{days}} days, {{count}} gamedays)",
+      "recent": "Lookback ({{count}} gamedays)"
     },
     "card": {
       "gamesScheduled": "Games scheduled",

--- a/journey_dashboard/src/types/progressTypes.ts
+++ b/journey_dashboard/src/types/progressTypes.ts
@@ -62,6 +62,7 @@ export interface GameProgressState {
 
   // Metadata
   totalLiveGames: number;
+  totalPlayedGamesToday: number;
   todayGamedayCount: number;
 }
 

--- a/liveticker/package-lock.json
+++ b/liveticker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveticker",
-  "version": "3.19.8",
+  "version": "3.19.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveticker",
-      "version": "3.19.8",
+      "version": "3.19.12",
       "dependencies": {
         "@reduxjs/toolkit": "^2.11.2",
         "axios": "^1.16.0",
@@ -1406,9 +1406,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1426,9 +1423,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,9 +1440,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,9 +1457,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1486,9 +1474,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1506,9 +1491,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3453,9 +3435,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3477,9 +3456,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3501,9 +3477,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3525,9 +3498,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/passcheck/package-lock.json
+++ b/passcheck/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passcheck",
-  "version": "3.19.10",
+  "version": "3.19.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "passcheck",
-      "version": "3.19.10",
+      "version": "3.19.12",
       "dependencies": {
         "@types/node": "^25.0.2",
         "@types/react": "^19.2.7",
@@ -2032,9 +2032,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2052,9 +2049,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2072,9 +2066,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2092,9 +2083,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2112,9 +2100,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2132,9 +2117,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4504,9 +4486,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4528,9 +4507,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4552,9 +4528,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4576,9 +4549,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/scorecard/package-lock.json
+++ b/scorecard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorecard",
-  "version": "3.19.8",
+  "version": "3.19.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorecard",
-      "version": "3.19.8",
+      "version": "3.19.12",
       "dependencies": {
         "@redux-devtools/extension": "^4.0.0",
         "@reduxjs/toolkit": "^2.11.2",
@@ -1418,9 +1418,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,9 +1435,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1458,9 +1452,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1478,9 +1469,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,9 +1486,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1518,9 +1503,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3471,9 +3453,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3495,9 +3474,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3519,9 +3495,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3543,9 +3516,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
This PR updates the game progress dashboard to:
1. Show 'UPCOMING' (Anstehend) instead of 'LIVE' for today's gamedays if no games have started yet.
2. Hide the progress bar and 0% completion for these upcoming gamedays.
3. Show the countdown ('X min until start') for today's gamedays in the top section.
4. Update the section title to 'HEUTE' (TODAY) if no games are live yet, or 'LIVE (X GAMES)' if activity is detected.