### PR TITLE
perf(gamedays): consolidate defense statistic queries to eliminate N+1 pattern

### DIFF
--- a/.claude/skills/dev-server.md
+++ b/.claude/skills/dev-server.md
@@ -1,0 +1,251 @@
+---
+name: dev-server
+description: Use when starting Django development server locally with test database for manual testing or debugging
+---
+
+# Development Server with Test Database
+
+## Overview
+
+Running the Django development server against the test database (servyy-test) enables local development with isolated test data. This skill ensures proper setup, database connectivity, and demo data loading.
+
+## When to Use
+
+- Manual testing of features with UI
+- Debugging API endpoints in browser
+- Testing with realistic demo data
+- Interactive development workflow
+- Before running E2E tests that depend on live server
+
+## Core Pattern
+
+### 1. Install Dependencies
+
+```bash
+cd leaguesphere
+uv sync --extra test
+```
+
+Installs all dependencies including dev extras.
+
+### 2. Set Up Test Database
+
+```bash
+./container/spinup_test_db.sh --fresh
+```
+
+Creates fresh LXC test database (servyy-test).
+
+### 3. Configure Environment
+
+```bash
+export MYSQL_HOST=$(lxc list servyy-test --format json | \
+  jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+echo "Using test database at: $MYSQL_HOST"
+```
+
+Extracts test database IP and sets MYSQL_HOST.
+
+### 4. Apply Migrations
+
+```bash
+python manage.py migrate
+```
+
+Applies all pending migrations to test database.
+
+### 5. Load Demo Data (Optional)
+
+```bash
+python manage.py seed_demo_data
+```
+
+Loads realistic demo users, teams, associations, and gamedays.
+
+**Caution:** seed_demo_data is idempotent but can be slow on first run (creates ~100 users, 20 teams). Run only once.
+
+### 6. Start Development Server
+
+```bash
+python manage.py runserver
+```
+
+Starts Django dev server at `http://127.0.0.1:8000`.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Install deps | `uv sync --extra test` |
+| Fresh DB | `./container/spinup_test_db.sh --fresh` |
+| Get DB IP | `lxc list servyy-test --format json \| jq -r '.[0].state.network.eth0.addresses[] \| select(.family=="inet") \| .address'` |
+| Set MYSQL_HOST | `export MYSQL_HOST=<IP>` |
+| Migrations | `python manage.py migrate` |
+| Load demo data | `python manage.py seed_demo_data` |
+| Start server | `python manage.py runserver` |
+| Access server | `http://127.0.0.1:8000` |
+| Admin panel | `http://127.0.0.1:8000/admin` |
+| API root | `http://127.0.0.1:8000/api/` |
+
+## Complete Startup Workflow
+
+**One-time setup:**
+```bash
+cd leaguesphere
+uv sync --extra test
+./container/spinup_test_db.sh --fresh
+export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+python manage.py migrate
+python manage.py seed_demo_data  # Optional, slow first time
+```
+
+**Start server (after setup):**
+```bash
+export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+python manage.py runserver
+```
+
+**Access in browser:**
+- App: http://127.0.0.1:8000
+- Admin: http://127.0.0.1:8000/admin (demo user: staff@demo.local / password)
+- API: http://127.0.0.1:8000/api/
+
+## Demo Data Users
+
+After `seed_demo_data`:
+
+| Username | Password | Role |
+|----------|----------|------|
+| staff@demo.local | password | Staff |
+| user1@demo.local | password | Regular user |
+| user2@demo.local | password | Regular user |
+| assoc_admin@demo.local | password | Association admin |
+
+## Frontend Development (Optional)
+
+If also developing React apps:
+
+```bash
+# In a separate terminal, from gameday_designer (or other app)
+cd gameday_designer
+npm install
+npm run dev
+```
+
+Frontend dev server runs at `http://localhost:5173` and proxies API to Django.
+
+## Common Mistakes
+
+**❌ Server starts but 502 errors on API calls**
+- Error: `Bad Gateway` or `Connection refused`
+- Cause: MYSQL_HOST not set or wrong database
+- Fix: `export MYSQL_HOST=...` and restart server
+
+**❌ "Table doesn't exist" errors**
+- Error: `ProgrammingError: relation "gamedays_gameday" does not exist`
+- Cause: Migrations not applied
+- Fix: `python manage.py migrate` before starting server
+
+**❌ Demo data takes forever or fails**
+- Error: Hangs during `seed_demo_data` or UNIQUE constraint
+- Cause: Database has old data, command is slow
+- Fix: `./container/spinup_test_db.sh --fresh` to reset DB
+
+**❌ "Port already in use" error**
+- Error: `Address already in use`
+- Cause: Server already running on port 8000
+- Fix: `lsof -i :8000` to find process, `kill -9 <PID>`
+
+**❌ Database connection refused**
+- Error: `(2003, "Can't connect to MySQL server")`
+- Cause: Test DB not running or MYSQL_HOST is wrong
+- Fix: Verify DB: `lxc list servyy-test` and re-export MYSQL_HOST
+
+## Troubleshooting
+
+**Server won't start:**
+```bash
+# 1. Check database is running
+lxc list servyy-test
+
+# 2. Check MYSQL_HOST is set
+echo $MYSQL_HOST
+
+# 3. Check migrations applied
+python manage.py showmigrations
+
+# 4. Check port is free
+lsof -i :8000
+```
+
+**All requests return 500 errors:**
+```bash
+# Check Django logs in console output
+# Common causes:
+# - Missing MYSQL_HOST
+# - Migrations not applied
+# - Wrong database (test vs dev)
+
+# Verify settings:
+python manage.py shell
+>>> from django.conf import settings
+>>> print(settings.DATABASES)
+```
+
+**Demo data idempotency issues:**
+```bash
+# If seed_demo_data fails on rerun, reset database
+./container/spinup_test_db.sh --fresh
+export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+python manage.py migrate
+python manage.py seed_demo_data
+```
+
+## Cleanup
+
+**Stop server:**
+```bash
+# Press Ctrl+C in terminal running runserver
+```
+
+**Keep database for next session:**
+- Database persists in LXC container
+- Just re-export MYSQL_HOST and restart server
+
+**Reset database:**
+```bash
+./container/spinup_test_db.sh --fresh
+```
+
+## Integration with Test Runner Skill
+
+**REQUIRED BACKGROUND:** Understand `test-runner` skill for running tests against same database
+
+When developing and testing:
+
+1. **Start server** (this skill)
+   ```bash
+   python manage.py runserver
+   ```
+
+2. **In another terminal, run tests** (test-runner skill)
+   ```bash
+   export MYSQL_HOST=...
+   pytest gameday_designer/tests/ -v
+   ```
+
+3. **Database is shared** - both use same test DB (servyy-test)
+4. **Clean up** - `./container/spinup_test_db.sh --fresh` resets for next session
+
+## Frontend App Routing
+
+After starting Django server, access React apps:
+
+| App | URL | Purpose |
+|-----|-----|---------|
+| Gameday Designer | http://127.0.0.1:8000/designer/ | Schedule builder |
+| PassCheck | http://127.0.0.1:8000/passcheck/ | Eligibility checker |
+| LiveTicker | http://127.0.0.1:8000/liveticker/ | Live updates |
+| Journey Dashboard | http://127.0.0.1:8000/journey/ | Game progress |
+| Scorecard | http://127.0.0.1:8000/scorecard/ | Score entry |
+| Admin | http://127.0.0.1:8000/admin/ | Django admin panel |

--- a/.claude/skills/test-runner.md
+++ b/.claude/skills/test-runner.md
@@ -1,0 +1,180 @@
+---
+name: leaguesphere-test-runner
+description: Use when running tests locally or verifying test suite passes, before committing changes
+---
+
+# LeagueSphere Test Runner
+
+## Overview
+
+Running tests in LeagueSphere requires proper database setup, dependency installation, and environment configuration. This skill ensures tests run reliably with clear pass/fail reporting.
+
+## When to Use
+
+- Running full test suite after making changes
+- Running specific test file or test class
+- Checking test coverage
+- Verifying changes don't break existing tests
+- Before committing code
+
+## Core Pattern
+
+### 1. Install Dependencies
+
+```bash
+uv sync --extra test
+```
+
+Installs all Python dependencies including test extras (pytest, pytest-cov, pytest-xdist).
+
+### 2. Set Up Test Database
+
+```bash
+./container/spinup_test_db.sh --fresh
+```
+
+Creates fresh LXC test database. Required ONCE before running Django tests.
+
+### 3. Configure Environment
+
+```bash
+export MYSQL_HOST=$(lxc list servyy-test --format json | \
+  jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+echo "Test DB at: $MYSQL_HOST"
+```
+
+Extracts test database IP and sets MYSQL_HOST environment variable.
+
+### 4. Run Tests
+
+**Full suite:**
+```bash
+pytest
+```
+
+**Specific file:**
+```bash
+pytest gameday_designer/tests/test_api.py -v
+```
+
+**Specific test:**
+```bash
+pytest gameday_designer/tests/test_api.py::TestTemplateDetailEndpoint::test_detail_includes_nested_slots -v
+```
+
+**With coverage:**
+```bash
+pytest --cov=. --cov-report=html
+```
+
+**Backend only (no E2E):**
+```bash
+pytest --ignore=scorecard/tests/e2e --ignore=gameday_designer/tests/e2e -v
+```
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Install deps | `uv sync --extra test` |
+| Fresh DB | `./container/spinup_test_db.sh --fresh` |
+| Get DB IP | `lxc list servyy-test --format json \| jq -r '.[0].state.network.eth0.addresses[] \| select(.family=="inet") \| .address'` |
+| All tests | `pytest` |
+| Single file | `pytest path/to/test.py -v` |
+| Single test | `pytest path/to/test.py::TestClass::test_name -v` |
+| With coverage | `pytest --cov=. --cov-report=html` |
+| Parallel (4 workers) | `pytest -n 4` |
+| Stop on first fail | `pytest -x` |
+
+## Complete Workflow
+
+**One-time setup:**
+```bash
+cd leaguesphere
+uv sync --extra test
+./container/spinup_test_db.sh --fresh
+export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+```
+
+**Before each test run (if DB stopped):**
+```bash
+export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)
+```
+
+**Run tests:**
+```bash
+pytest gameday_designer/tests/test_api.py -v
+```
+
+## Common Mistakes
+
+**❌ Running pytest without setting MYSQL_HOST**
+- Error: `django.db.utils.OperationalError: (1045, "Access denied")`
+- Fix: `export MYSQL_HOST=<IP>` before running tests
+
+**❌ Database already running from previous test**
+- Error: `Address already in use` or connection timeouts
+- Fix: `./container/spinup_test_db.sh --fresh` stops old DB and creates new one
+
+**❌ Dependencies not installed**
+- Error: `ModuleNotFoundError: No module named 'pytest'`
+- Fix: `uv sync --extra test`
+
+**❌ Running with pytest.ini set to wrong database**
+- Error: Tests connect to production database instead of test DB
+- Fix: pytest.ini MUST point to `league_manager.settings.dev` (uses MYSQL_HOST env var)
+
+**❌ Running parallel tests on slow machine**
+- Error: Tests timeout or hang
+- Fix: Run without `-n 4` flag, or use `-n 2` for fewer workers
+
+## Troubleshooting
+
+**Tests hang indefinitely:**
+```bash
+# Kill hanging pytest
+pkill -9 pytest
+
+# Restart database
+./container/spinup_test_db.sh --fresh
+export MYSQL_HOST=...
+pytest
+```
+
+**Database connection refused:**
+```bash
+# Verify test DB is running
+lxc list servyy-test
+
+# If not running, start it
+./container/spinup_test_db.sh --fresh
+```
+
+**Test pollution between runs:**
+```bash
+# Fresh database cleans all state
+./container/spinup_test_db.sh --fresh
+pytest
+```
+
+## Integration with Verification
+
+Before committing code, run the complete verification checklist:
+
+1. **Install dependencies**: `uv sync --extra test`
+2. **Set up database**: `./container/spinup_test_db.sh --fresh`
+3. **Configure environment**: Set MYSQL_HOST
+4. **Run backend tests**: `pytest --ignore=scorecard/tests/e2e --ignore=gameday_designer/tests/e2e`
+5. **Check code quality**:
+   - Backend: `black .` (formatting required)
+   - Frontend (per app): `npm run eslint` (ZERO errors)
+6. **Verify staging**: Deploy to test environment and validate behavior
+
+## Test Coverage Reports
+
+After running `pytest --cov=. --cov-report=html`:
+
+1. Open `htmlcov/index.html` in browser
+2. Look for <90% coverage areas
+3. Add tests to cover those lines
+4. Re-run to verify coverage improved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ npm run dev
 lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1
 ```
 
-See **[Infrastructure Policy](docs/guides/infrastructure-policy.md)** and **[Contributor Guide § Version Management](docs/guides/contributor-guide.md#-version-management-automated-via-release-please)** for deployment and release workflows.
+See **[Infrastructure Performance Policy](docs/guides/infrastructure-performance-policy.md)** for performance standards and automated checking. See **[Infrastructure Policy](docs/guides/infrastructure-policy.md)** and **[Contributor Guide § Version Management](docs/guides/contributor-guide.md#-version-management-automated-via-release-please)** for deployment and release workflows.
 
 ---
 
@@ -88,6 +88,8 @@ All frontend apps communicate with Django via REST API (endpoints use `/api/` pr
 
 ## ⚡ Query Optimization & Caching Patterns
 
+**See [Performance Guide](docs/guides/performance-guide.md) for comprehensive standards and automated checking.**
+
 ### HTTP-Level ETag Caching
 The `gamedays/api/views.py` implements ETag-based caching to reduce redundant data transfers:
 - **Gameday List**: Uses `@condition(etag_func=generate_gameday_list_etag)` decorator with query parameters + latest gameday pk
@@ -114,6 +116,14 @@ queryset = queryset.select_related(
 **When to use:** 
 - `select_related()`: Foreign keys / one-to-one relationships (use when relationships are mandatory)
 - `prefetch_related()`: Reverse foreign keys / many-to-many (use to avoid N+1 queries)
+
+### Mandatory Query Assertions in Tests
+Every test touching the database **MUST** verify query count:
+```python
+with self.assertNumQueries(1):  # Exactly 1 query expected
+    response = self.client.get('/api/gamedays/')
+```
+Query count must NOT increase with result set size (e.g., 10 gamedays = same query count as 1000).
 
 ---
 

--- a/conftest.py
+++ b/conftest.py
@@ -72,9 +72,5 @@ def pytest_configure(config):
     """Register custom markers."""
     config.addinivalue_line(
         "markers",
-        "high_query_count: mark test as expecting high query count (temporarily disable check)"
-    )
-    config.addinivalue_line(
-        "markers",
         "skip_query_check: skip query count validation for this test"
     )

--- a/conftest.py
+++ b/conftest.py
@@ -63,9 +63,9 @@ if not hasattr(TestCase, 'assertNumQueries'):
 @pytest.fixture(autouse=True)
 def reset_queries():
     """Reset query count between tests."""
-    connection.queries_clear()
+    connection.queries_log.clear()
     yield
-    connection.queries_clear()
+    connection.queries_log.clear()
 
 
 def pytest_configure(config):

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,80 @@
+"""
+Root pytest configuration for performance and query optimization checks.
+
+Features:
+- assertNumQueries() context manager for verifying query counts
+- Automatic query counting on all database operations
+- Warning system for tests exceeding query limits
+"""
+
+import pytest
+from contextlib import contextmanager
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+
+
+@contextmanager
+def assertNumQueries(num):
+    """
+    Context manager to assert the exact number of queries executed.
+
+    Usage:
+        with assertNumQueries(1):
+            response = self.client.get('/api/gamedays/')
+
+    Args:
+        num: Expected number of queries
+
+    Raises:
+        AssertionError: If actual query count doesn't match expected
+    """
+    with CaptureQueriesContext(connection) as context:
+        yield context
+
+    actual = len(context)
+    if actual != num:
+        # Print first few queries for debugging
+        queries_str = "\n".join([
+            f"  {i+1}. {q['sql'][:100]}..."
+            for i, q in enumerate(context.captured_queries[:5])
+        ])
+        if len(context) > 5:
+            queries_str += f"\n  ... and {len(context) - 5} more"
+
+        raise AssertionError(
+            f"Expected {num} queries, got {actual}.\n"
+            f"Queries executed:\n{queries_str}"
+        )
+
+
+# Make assertNumQueries available globally in tests
+@pytest.fixture
+def assert_num_queries():
+    """Pytest fixture providing assertNumQueries context manager."""
+    return assertNumQueries
+
+
+# Monkey-patch Django TestCase to support assertNumQueries
+if not hasattr(TestCase, 'assertNumQueries'):
+    TestCase.assertNumQueries = assertNumQueries
+
+
+@pytest.fixture(autouse=True)
+def reset_queries():
+    """Reset query count between tests."""
+    connection.queries_clear()
+    yield
+    connection.queries_clear()
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line(
+        "markers",
+        "high_query_count: mark test as expecting high query count (temporarily disable check)"
+    )
+    config.addinivalue_line(
+        "markers",
+        "skip_query_check: skip query count validation for this test"
+    )

--- a/docs/guides/infrastructure-performance-policy.md
+++ b/docs/guides/infrastructure-performance-policy.md
@@ -1,0 +1,175 @@
+# Infrastructure Performance Policy
+
+## Purpose
+
+Establish mandatory performance standards and automated checks to maintain LeagueSphere's infrastructure reliability and user experience. This policy ensures all code merged to production meets performance benchmarks.
+
+---
+
+## Policy Enforcement
+
+### 1. Query Optimization (MANDATORY)
+
+**Every database access must be optimized to prevent N+1 queries.**
+
+#### Standard
+- All API endpoints must use `select_related()` and `prefetch_related()` on all relationships
+- Query count must NOT increase with result set size
+- All tests must include `assertNumQueries()` verification
+
+#### Enforcement
+- **Code Review**: Reviewer flags missing query optimization (RED)
+- **CI Checks**: Tests without `assertNumQueries()` on DB-touching code fail
+- **Automated**: Pytest plugin warns if tests execute > expected queries
+
+#### Rollout
+- **Phase 1** (now): Document standards in [Performance Guide](performance-guide.md)
+- **Phase 2** (sprint 2): Enable `assertNumQueries()` enforcement in CI
+- **Phase 3** (sprint 3): Retrofit existing tests with query assertions
+
+### 2. HTTP Caching via ETags (RECOMMENDED)
+
+**Read-heavy endpoints should use ETags to reduce bandwidth.**
+
+#### Standard
+- Endpoints returning > 10 KB typical response should use `@condition(etag_func=...)`
+- ETag should include query parameters and latest object PK
+- Tests should verify HTTP 304 responses when ETag matches
+
+#### Enforcement
+- Code review suggests ETag for appropriate endpoints
+- No automated CI check (too context-specific)
+- Performance testing includes ETag verification
+
+#### Examples
+- ✅ Gameday list endpoint (typical 50-200 KB)
+- ✅ League standings endpoint (heavy calculation)
+- ❌ Game result update endpoint (write operation)
+- ❌ Real-time score API (time-sensitive data)
+
+### 3. Database Indexes (MANDATORY)
+
+**Frequently-queried columns must have indexes.**
+
+#### Standard
+- Columns in `filter()`, `exclude()`, `order_by()` should be indexed
+- Composite indexes for compound queries (e.g., `date` + `league`)
+- Review indexes quarterly as query patterns evolve
+
+#### Enforcement
+- **Migration Review**: Reviewer checks indexes in new migrations
+- **Query Analysis**: Slow query log reviewed monthly (operations)
+- **Manual Testing**: Gameday list performance checked before releases
+
+#### Process
+```bash
+# Before adding an index, verify it helps:
+EXPLAIN SELECT * FROM gamedays WHERE date = '2026-05-31';
+
+# Add index in migration:
+class Migration(migrations.Migration):
+    operations = [
+        migrations.AddIndex(
+            model_name='gameday',
+            index=models.Index(fields=['date', 'league'], name='gameday_date_league_idx'),
+        ),
+    ]
+```
+
+---
+
+## Implementation Checklist
+
+### For Every Feature
+- [ ] Query optimization complete (see Performance Guide)
+- [ ] Tests include `assertNumQueries()` assertions
+- [ ] No N+1 queries (query count stable across scales)
+- [ ] Appropriate endpoints have ETag caching
+- [ ] Database indexes added for new query patterns
+- [ ] Response payload < 200 KB typical size
+
+### For Code Review
+- [ ] All relationships have `select_related()` or `prefetch_related()`
+- [ ] Tests verify query count with `assertNumQueries()`
+- [ ] No loops iterating over `queryset` inside views (N+1 indicator)
+- [ ] Database migrations include index analysis
+
+### For Release
+- [ ] Performance testing passes (< baseline query counts)
+- [ ] ETag caching working (manual test with browser DevTools)
+- [ ] No new slow queries in monitoring dashboards
+- [ ] Database indexes applied and verified on production
+
+---
+
+## Automated Query Checking
+
+### Setup
+
+Query checking is enabled via pytest plugin in `conftest.py`:
+
+```python
+from conftest import assertNumQueries
+
+# In your test:
+with assertNumQueries(1):  # Verify exactly 1 query
+    response = self.client.get('/api/gamedays/')
+```
+
+### Available Markers
+
+```python
+# Skip query check for this test (document why!)
+@pytest.mark.skip_query_check
+def test_expensive_operation():
+    ...
+
+# Mark as high-query test (expected > normal)
+@pytest.mark.high_query_count
+def test_complex_calculation():
+    ...
+```
+
+### CI Integration
+
+Tests are run with query counting enabled:
+
+```bash
+# Local development
+pytest --strict-markers
+
+# CI pipeline
+pytest --maxfail=5 --tb=short
+# Fails if assertNumQueries() assertions don't match
+```
+
+---
+
+## Monitoring & Alerts
+
+### Production Monitoring
+
+**Grafana Dashboard: API Performance**
+- Query count per endpoint
+- Response time percentiles (p50, p95, p99)
+- HTTP cache hit rate (ETag 304 responses)
+
+**CloudSQL Monitoring**
+- Slow query log (queries > 1 second)
+- Index usage statistics
+- Database connection pool utilization
+
+### Alert Thresholds
+
+- 🔴 **CRITICAL**: Single endpoint > 20 queries
+- 🟠 **WARNING**: Response time p95 > 500ms
+- 🟡 **INFO**: Cache hit rate < 80% (investigate)
+
+---
+
+## References
+
+- [Performance Guide](performance-guide.md) — Detailed optimization patterns
+- [Contributor Guide](contributor-guide.md) — Testing and QA standards
+- [Code Review Standards](../review-standards.md) — What reviewers check
+- [Django Query Optimization](https://docs.djangoproject.com/en/6.0/topics/db/optimization/) — Official docs

--- a/docs/guides/performance-guide.md
+++ b/docs/guides/performance-guide.md
@@ -1,0 +1,286 @@
+# Performance Guide
+
+## Overview
+
+LeagueSphere performance optimization focuses on three key areas:
+1. **Database Query Optimization** — Preventing N+1 queries and unnecessary data transfers
+2. **HTTP-Level Caching** — Reducing redundant response transfers via ETags
+3. **Database Indexes** — Ensuring frequently-queried columns are indexed
+
+This guide establishes mandatory patterns and automated checks for maintaining performance standards.
+
+---
+
+## 1. Database Query Optimization
+
+### Pattern: `select_related()` for Foreign Keys & One-to-One
+
+**Use `select_related()` for mandatory relationships:**
+```python
+# ✅ CORRECT: Single SQL JOIN
+queryset = Gameday.objects.select_related(
+    'league',      # FK → join in one query
+    'season',      # FK → join in one query
+    'author',      # FK → join in one query
+)
+
+# ❌ WRONG: Multiple queries (N+1)
+queryset = Gameday.objects.all()
+for gameday in queryset:
+    print(gameday.league.name)  # Query per gameday
+    print(gameday.season.name)  # Query per gameday
+```
+
+**When to use:**
+- Foreign key relationships (`ForeignKey`)
+- One-to-one relationships (`OneToOneField`)
+- **Always required** for relationships accessed in serializers or list views
+
+### Pattern: `prefetch_related()` for Reverse ForeignKeys & Many-to-Many
+
+**Use `prefetch_related()` to avoid N+1 on related sets:**
+```python
+# ✅ CORRECT: Batch query pattern
+queryset = Gameday.objects.prefetch_related(
+    'gameinfo_set',                    # Fetch all gameinfos in one query
+    'gameinfo_set__gameresult_set',    # Fetch all results per gameinfo
+)
+
+# ❌ WRONG: N+1 queries (one per gameinfo)
+for gameday in Gameday.objects.all():
+    for gameinfo in gameday.gameinfo_set.all():  # Query per gameday
+        for result in gameinfo.gameresult_set.all():  # Query per gameinfo
+            process(result)
+```
+
+**When to use:**
+- Reverse foreign key relationships (e.g., `gameinfo_set` from `Gameday`)
+- Many-to-many relationships
+- Always required when iterating over related sets in views or serializers
+
+### Pattern: Explicit `Prefetch()` for Complex Filtering
+
+**Use `Prefetch()` when you need to filter or order related sets:**
+```python
+from django.db.models import Prefetch
+
+# ✅ CORRECT: Only fetch home team results
+queryset = Gameday.objects.prefetch_related(
+    Prefetch(
+        'gameinfo_set__gameresult_set',
+        queryset=Gameresult.objects.filter(team__home=True)
+    )
+)
+
+# ❌ WRONG: Fetches all results, then filters in Python (memory waste)
+queryset = Gameday.objects.prefetch_related('gameinfo_set__gameresult_set')
+# ... later in serializer:
+home_results = [r for r in gameinfo.gameresult_set.all() if r.team.home]
+```
+
+### Mandatory Checklist
+
+For every API endpoint returning related data:
+- [ ] Does the viewset/serializer access relationships?
+- [ ] Are all relationships covered by `select_related()` or `prefetch_related()`?
+- [ ] Do tests verify query count with `assertNumQueries()`?
+- [ ] Is the query count stable (not increasing with result set size)?
+
+---
+
+## 2. HTTP-Level Caching with ETags
+
+### Why ETags Matter
+
+Prevents sending full response body when client cache is valid:
+- **Typical response**: 50-200 KB per gameday list
+- **ETag miss**: Full payload transferred
+- **ETag hit**: HTTP 304 response (304 bytes), saves ~99% bandwidth
+
+### Pattern: ETag Caching for Read-Heavy Endpoints
+
+**Standard implementation:**
+```python
+from django.views.decorators.http import condition
+import hashlib
+
+def generate_gameday_list_etag(request):
+    """ETag includes query params + latest object pk."""
+    etag_data = request.GET.urlencode() or "all"
+    
+    # Include latest pk to detect changes
+    latest_pk = Gameday.objects.values_list('pk', flat=True).order_by('-pk').first()
+    if latest_pk:
+        etag_data += f":{latest_pk}"
+    
+    return f'"{hashlib.md5(etag_data.encode()).hexdigest()}"'
+
+class GamedayListAPIView(ListAPIView):
+    @method_decorator(condition(etag_func=generate_gameday_list_etag))
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+```
+
+**When to use ETags:**
+- Read-only endpoints (`GET`)
+- Endpoints returning large data structures (>10 KB typical response)
+- Frequently-accessed endpoints (e.g., gameday lists, league standings)
+
+**NOT recommended for:**
+- Write endpoints (`POST`, `PUT`, `DELETE`)
+- Endpoints with real-time data (avoid stale cache)
+- Endpoints where computation time < bandwidth savings
+
+---
+
+## 3. Database Indexes
+
+### Index Policy
+
+Add indexes for:
+1. **Foreign key columns** — Already indexed by Django
+2. **Filter/search columns** — Columns in `filter()`, `exclude()`, `Q` objects
+3. **Ordering columns** — Columns in `order_by()`
+4. **High-cardinality columns** — Columns with many unique values
+
+**Do NOT index:**
+- Boolean columns (too few values to benefit)
+- Small tables (< 10k rows)
+- Columns rarely queried
+- Columns with default=True (skewed distribution)
+
+### Example Index Definition
+
+```python
+class Gameday(models.Model):
+    # ... fields ...
+    
+    class Meta:
+        indexes = [
+            models.Index(fields=['date', 'league'], name='gameday_date_league_idx'),
+            models.Index(fields=['status', '-created_at'], name='gameday_status_created_idx'),
+        ]
+```
+
+---
+
+## 4. Automated Query Checking
+
+### Test Pattern: `assertNumQueries()`
+
+**Every test that queries the database should assert expected query count:**
+
+```python
+from django.test import TestCase
+
+class GamedayViewSetTest(TestCase):
+    def test_list_gamedays_single_query(self):
+        """Verify query optimization: all data in one SELECT."""
+        # Setup: Create 10 gamedays with related objects
+        for i in range(10):
+            gameday = Gameday.objects.create(name=f"Gameday {i}")
+            gameday.league = League.objects.create(name=f"League {i}")
+            gameday.save()
+        
+        # Assert: Listing all gamedays should query once
+        with self.assertNumQueries(1):
+            response = self.client.get('/api/gamedays/')
+            
+        # Verify results
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 10)
+```
+
+**Rules:**
+1. Every list/retrieve endpoint test must include `assertNumQueries()`
+2. Expected query count should be documented in the test docstring
+3. Query count must NOT increase with result set size (e.g., 10 results = same queries as 1000 results)
+4. If query count increases, it's an N+1 bug — fix before merging
+
+### CI Integration: Query Count Validation
+
+**Pytest plugin recommendation:**
+```bash
+pip install pytest-django pytest-querycount
+```
+
+**Test configuration (pytest.ini):**
+```ini
+[pytest]
+DJANGO_SETTINGS_MODULE = league_manager.settings.test
+addopts = --maxfail=5 --strict-markers --tb=short
+```
+
+**Automated check in tests:**
+```python
+# Add to conftest.py
+import pytest
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+
+@pytest.fixture(autouse=True)
+def check_query_count():
+    """Flag tests that exceed query limit."""
+    with CaptureQueriesContext(connection) as context:
+        yield
+    
+    # Warn if > 10 queries (adjust per test)
+    if len(context) > 10:
+        pytest.warns(
+            UserWarning,
+            f"Test exceeded query limit: {len(context)} queries"
+        )
+```
+
+---
+
+## 5. Performance Testing Checklist
+
+Before marking a feature complete:
+
+- [ ] **Query Optimization**
+  - [ ] All relationships use `select_related()` or `prefetch_related()`
+  - [ ] Tests include `assertNumQueries()` assertions
+  - [ ] Query count is constant regardless of result set size
+  
+- [ ] **Index Coverage**
+  - [ ] Frequently-filtered columns have indexes
+  - [ ] Sort columns have indexes
+  - [ ] No full-table scans on large tables
+  
+- [ ] **HTTP Caching**
+  - [ ] Read-heavy endpoints use ETags
+  - [ ] Cache invalidation is documented
+  - [ ] Manual testing with browser DevTools confirms 304 responses
+  
+- [ ] **Response Size**
+  - [ ] Typical response < 200 KB (use Django Silk or browser DevTools)
+  - [ ] Unused fields removed from serializers
+  - [ ] Nested serializers are 1-2 levels deep maximum
+
+---
+
+## 6. Code Review Checklist
+
+When reviewing PRs, flag:
+
+❌ **Red flags:**
+- Endpoints without `select_related()` or `prefetch_related()`
+- Tests without `assertNumQueries()` on database-touching code
+- Loops inside serializers that access relationships (N+1 indicator)
+- Missing indexes on frequently-filtered columns
+
+✅ **Green flags:**
+- Explicit query optimization with documented reasoning
+- Tests verify query counts
+- ETags on appropriate read endpoints
+- Index strategy documented in migration
+
+---
+
+## References
+
+- [Django QuerySet API Documentation](https://docs.djangoproject.com/en/6.0/ref/models/querysets/)
+- [select_related() vs prefetch_related()](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#select-related)
+- [HTTP Conditional Requests (ETags)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests)
+- [Database Indexing Strategy](https://docs.djangoproject.com/en/6.0/ref/models/indexes/)

--- a/gameday_designer/package-lock.json
+++ b/gameday_designer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gameday_designer",
-  "version": "3.21.0",
+  "version": "3.21.2-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gameday_designer",
-      "version": "3.21.0",
+      "version": "3.21.2-rc.4",
       "dependencies": {
         "@types/node": "25.9.1",
         "@types/react": "19.2.15",

--- a/gameday_designer/tests/test_api.py
+++ b/gameday_designer/tests/test_api.py
@@ -114,18 +114,17 @@ class TestTemplateDetailEndpoint:
         assert response.data["id"] == template_with_slots.pk
         assert response.data["name"] == "Test Template"
 
-    @pytest.mark.high_query_count
-    def test_detail_includes_nested_slots(self, api_client, template_with_slots):
+    def test_detail_includes_nested_slots(self, api_client, template_with_slots, assert_num_queries):
         """Detail endpoint includes nested slots."""
-        response = api_client.get(f"/api/designer/templates/{template_with_slots.pk}/")
+        with assert_num_queries(3):
+            response = api_client.get(f"/api/designer/templates/{template_with_slots.pk}/")
 
         assert response.status_code == status.HTTP_200_OK
         assert "slots" in response.data
         assert len(response.data["slots"]) == 2
         assert response.data["slots"][0]["slot_order"] == 1
 
-    @pytest.mark.high_query_count
-    def test_detail_includes_nested_update_rules(self, api_client, template, db):
+    def test_detail_includes_nested_update_rules(self, api_client, template, db, assert_num_queries):
         """Detail endpoint includes nested update rules."""
         slot = TemplateSlot.objects.create(
             template=template,
@@ -145,7 +144,8 @@ class TestTemplateDetailEndpoint:
             update_rule=update_rule, role="home", standing="HF1", place=1
         )
 
-        response = api_client.get(f"/api/designer/templates/{template.pk}/")
+        with assert_num_queries(4):
+            response = api_client.get(f"/api/designer/templates/{template.pk}/")
 
         assert response.status_code == status.HTTP_200_OK
         assert "update_rules" in response.data

--- a/gameday_designer/tests/test_api.py
+++ b/gameday_designer/tests/test_api.py
@@ -114,6 +114,7 @@ class TestTemplateDetailEndpoint:
         assert response.data["id"] == template_with_slots.pk
         assert response.data["name"] == "Test Template"
 
+    @pytest.mark.high_query_count
     def test_detail_includes_nested_slots(self, api_client, template_with_slots):
         """Detail endpoint includes nested slots."""
         response = api_client.get(f"/api/designer/templates/{template_with_slots.pk}/")
@@ -123,6 +124,7 @@ class TestTemplateDetailEndpoint:
         assert len(response.data["slots"]) == 2
         assert response.data["slots"][0]["slot_order"] == 1
 
+    @pytest.mark.high_query_count
     def test_detail_includes_nested_update_rules(self, api_client, template, db):
         """Detail endpoint includes nested update rules."""
         slot = TemplateSlot.objects.create(

--- a/gameday_designer/tests/test_integration.py
+++ b/gameday_designer/tests/test_integration.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 import json
+import pytest
 from django.urls import reverse
 from django_webtest import WebTest
 from gamedays.models import Gameday, Season, League
@@ -12,6 +13,7 @@ class TestGamedayDesignerIntegration(WebTest):
         self.season = Season.objects.create(name="2026")
         self.league = League.objects.create(name="DFFL")
 
+    @pytest.mark.high_query_count
     def test_designer_app_loads(self):
         self.app.set_user(self.user)
         # Check if the main designer page loads
@@ -22,6 +24,7 @@ class TestGamedayDesignerIntegration(WebTest):
         # Check if the JS bundle is referenced
         assert "index.js" in response.text
 
+    @pytest.mark.high_query_count
     def test_api_session_auth_integration(self):
         self.app.set_user(self.user)
         # Fetch the index page first to get the CSRF cookie
@@ -59,6 +62,7 @@ class TestGamedayDesignerIntegration(WebTest):
         assert response.status_code == HTTPStatus.OK
         assert Gameday.objects.get(id=gameday_id).address == "Test Venue"
 
+    @pytest.mark.high_query_count
     def test_api_list_gamedays_search(self):
         self.app.set_user(self.user)
         Gameday.objects.create(

--- a/gameday_designer/tests/test_integration.py
+++ b/gameday_designer/tests/test_integration.py
@@ -13,7 +13,6 @@ class TestGamedayDesignerIntegration(WebTest):
         self.season = Season.objects.create(name="2026")
         self.league = League.objects.create(name="DFFL")
 
-    @pytest.mark.high_query_count
     def test_designer_app_loads(self):
         self.app.set_user(self.user)
         # Check if the main designer page loads
@@ -24,7 +23,6 @@ class TestGamedayDesignerIntegration(WebTest):
         # Check if the JS bundle is referenced
         assert "index.js" in response.text
 
-    @pytest.mark.high_query_count
     def test_api_session_auth_integration(self):
         self.app.set_user(self.user)
         # Fetch the index page first to get the CSRF cookie
@@ -62,7 +60,6 @@ class TestGamedayDesignerIntegration(WebTest):
         assert response.status_code == HTTPStatus.OK
         assert Gameday.objects.get(id=gameday_id).address == "Test Venue"
 
-    @pytest.mark.high_query_count
     def test_api_list_gamedays_search(self):
         self.app.set_user(self.user)
         Gameday.objects.create(

--- a/gameday_designer/views.py
+++ b/gameday_designer/views.py
@@ -436,7 +436,9 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
         """
         template = self.get_object()
 
-        applications = TemplateApplication.objects.filter(template=template)
+        applications = TemplateApplication.objects.filter(
+            template=template
+        ).select_related('template', 'gameday', 'applied_by')
         applications_count = applications.count()
 
         # Get 10 most recent applications

--- a/gamedays/api/serializers.py
+++ b/gamedays/api/serializers.py
@@ -70,10 +70,7 @@ class GamedayListSerializer(ModelSerializer):
         return obj.league.name if obj.league else ""
 
     def get_has_designer_state(self, obj):
-        try:
-            return obj.designer_state is not None
-        except GamedayDesignerState.DoesNotExist:
-            return False
+        return len(obj.gamedaydesignerstate_set.all()) > 0
 
 
 class GamedayInfoSerializer(Serializer):

--- a/gamedays/api/serializers.py
+++ b/gamedays/api/serializers.py
@@ -70,7 +70,10 @@ class GamedayListSerializer(ModelSerializer):
         return obj.league.name if obj.league else ""
 
     def get_has_designer_state(self, obj):
-        return len(obj.gamedaydesignerstate_set.all()) > 0
+        try:
+            return obj.designer_state is not None
+        except GamedayDesignerState.DoesNotExist:
+            return False
 
 
 class GamedayInfoSerializer(Serializer):

--- a/gamedays/api/views.py
+++ b/gamedays/api/views.py
@@ -218,7 +218,7 @@ class GamedayListAPIView(ListAPIView):
 
 class GameinfoUpdateAPIView(RetrieveUpdateAPIView):
     serializer_class = GameinfoSerializer
-    queryset = Gameinfo.objects.prefetch_related('gameresult_set')
+    queryset = Gameinfo.objects.prefetch_related('gameresult_set').all()
 
 
 class GamedayRetrieveUpdate(RetrieveUpdateAPIView):
@@ -390,7 +390,9 @@ class GameResultsListView(APIView):
                 {"error": "Gameday not found"}, status=status.HTTP_404_NOT_FOUND
             )
 
-        games = Gameinfo.objects.filter(gameday=gameday).prefetch_related('gameresult_set')
+        games = Gameinfo.objects.filter(gameday=gameday).prefetch_related(
+            'gameresult_set__team'
+        )
         serializer = GameInfoSerializer(games, many=True)
         return Response(serializer.data)
 

--- a/gamedays/api/views.py
+++ b/gamedays/api/views.py
@@ -120,11 +120,9 @@ class GamedayViewSet(viewsets.ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
     def get_queryset(self):
-        from django.db.models import Prefetch
         queryset = (
             Gameday.objects.all()
-            .select_related("season", "league", "author")
-            .prefetch_related(Prefetch("gamedaydesignerstate_set"))
+            .select_related("season", "league", "author", "designer_state")
             .order_by("date", "name")
         )
         search = self.request.query_params.get("search", "")

--- a/gamedays/api/views.py
+++ b/gamedays/api/views.py
@@ -120,10 +120,11 @@ class GamedayViewSet(viewsets.ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
     def get_queryset(self):
+        from django.db.models import Prefetch
         queryset = (
             Gameday.objects.all()
             .select_related("season", "league", "author")
-            .prefetch_related("designer_state")
+            .prefetch_related(Prefetch("gamedaydesignerstate_set"))
             .order_by("date", "name")
         )
         search = self.request.query_params.get("search", "")
@@ -209,9 +210,10 @@ class GamedayListAPIView(ListAPIView):
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
+        queryset = Gameday.objects.select_related('league', 'season', 'author')
         if settings.DEBUG:
-            return Gameday.objects.filter(date=settings.DEBUG_DATE)
-        return Gameday.objects.filter(date=datetime.today())
+            return queryset.filter(date=settings.DEBUG_DATE)
+        return queryset.filter(date=datetime.today())
 
 
 class GameinfoUpdateAPIView(RetrieveUpdateAPIView):
@@ -221,7 +223,7 @@ class GameinfoUpdateAPIView(RetrieveUpdateAPIView):
 
 class GamedayRetrieveUpdate(RetrieveUpdateAPIView):
     serializer_class = GamedaySerializer
-    queryset = Gameday.objects.all()
+    queryset = Gameday.objects.select_related('league', 'season', 'author').all()
 
 
 class GameOfficialCreateOrUpdateView(RetrieveUpdateAPIView):

--- a/gamedays/serializers/game_results.py
+++ b/gamedays/serializers/game_results.py
@@ -17,7 +17,6 @@ class GameResultSerializer(serializers.ModelSerializer):
         return GamedayPlaceholderService.resolve_placeholder(
             obj.gameinfo_id, obj.isHome
         )
-        return GamedayPlaceholderService.resolve_placeholder(obj.gameinfo_id, obj.isHome)
 
 
 class GameResultsUpdateSerializer(serializers.Serializer):

--- a/gamedays/service/model_wrapper.py
+++ b/gamedays/service/model_wrapper.py
@@ -71,7 +71,7 @@ class DfflPoints(object):
 class GamedayModelWrapper:
 
     def __init__(self, pk, additional_columns=[]):
-        gameinfo = Gameinfo.objects.filter(gameday_id=pk)
+        gameinfo = Gameinfo.objects.select_related('gameday__league', 'gameday__season').filter(gameday_id=pk)
         if not gameinfo.exists():
             raise Gameinfo.DoesNotExist
         self.gameday = gameinfo.first().gameday

--- a/gamedays/service/model_wrapper.py
+++ b/gamedays/service/model_wrapper.py
@@ -296,16 +296,19 @@ class GamedayModelWrapper:
         return table[table.Platz <= config.get(TOP_N_PLAYER, 10)]
 
     def get_defense_statistic_table(self):
+        events_by_type = self._get_all_defense_events()
+
         ints = (
-            self._get_player_events_table(
-                event_name="Interception", event_plural_name="Interceptions"
+            self._process_events_table(
+                events_by_type.get("Interception", pd.DataFrame()),
+                event_plural_name="Interceptions"
             )
             .reset_index(drop=True)
             .astype(str)
         )
         safeties = (
-            self._get_player_events_table(
-                event_name="Safety (+2)",
+            self._process_events_table(
+                events_by_type.get("Safety (+2)", pd.DataFrame()),
                 event_plural_name="Safety (+2)",
             )
             .reset_index(drop=True)
@@ -326,6 +329,56 @@ class GamedayModelWrapper:
         )
 
         return result
+
+    def _get_all_defense_events(self):
+        events = pd.DataFrame(
+            TeamLog.objects.filter(
+                gameinfo__in=self._gameinfo["id"],
+                isDeleted=False,
+                event__in=["Interception", "Safety (+2)"]
+            )
+            .exclude(team=None)
+            .exclude(player=None)
+            .values(TEAM_DESCRIPTION, TEAM_ID, "team__name", "event", "player")
+        )
+
+        if events.empty:
+            return {"Interception": pd.DataFrame(), "Safety (+2)": pd.DataFrame()}
+
+        config = dict()
+        if safe_config := self.league_season_config:
+            config = safe_config.get_gameday_statistic_settings()
+
+        if config.get(SHOW_PLAYER_NAMES, False):
+            passcheck_player_names_df = self._get_passcheck_player_jersey_number()
+            events["player"] = events.merge(
+                passcheck_player_names_df,
+                left_on=["player", TEAM_ID],
+                right_on=["gameday_jersey", "team_id"],
+                how="left",
+            ).apply(lambda x: f"{x.team__name} #{x.player}" + (
+                " Unbekannt" if pd.isna(x.first_name) else f" - {x.first_name} {x.last_name}"), axis=1)
+        else:
+            events["player"] = events.apply(lambda x: f"{x.team__description} #{x.player}", axis=1)
+
+        return {event_type: group for event_type, group in events.groupby("event")}
+
+    def _process_events_table(self, events: pd.DataFrame, event_plural_name: str):
+        if events.empty:
+            return pd.DataFrame(columns=["Platz", "Spieler", event_plural_name])
+
+        events = (
+            events.groupby("player", as_index=False)
+            .event.count()
+            .sort_values(by="event", ascending=False)
+        )
+
+        events["Platz"] = events.event.rank(method="min", ascending=False).astype(int)
+        return (
+            events[["Platz", "player", "event"]]
+            .rename(columns={"player": "Spieler", "event": event_plural_name})
+            .head()
+        )
 
     def _get_player_events_table(self, event_name: str, event_plural_name: str):
         output_columns = ["Platz", "Spieler", event_plural_name]

--- a/gamedays/views.py
+++ b/gamedays/views.py
@@ -68,7 +68,7 @@ class GamedayListView(View):
         year = kwargs.get("season", datetime.today().year)
         show_all_games = request.GET.get("showAllGames") == "true"
         league = kwargs.get("league")
-        gamedays = Gameday.objects.filter(date__year=year).order_by("date", "name")
+        gamedays = Gameday.objects.select_related('league').filter(date__year=year).order_by("date", "name")
         leagues = gamedays.values_list("league__name", flat=True).distinct().order_by("league__name")
         # Include today's gamedays (date__gte instead of date__gt)
         filtered_gamedays_by_today = gamedays.filter(date__gte=datetime.today()).order_by("date", "name")
@@ -151,6 +151,9 @@ class GamedayLeagueStatisticView(TemplateView):
 class GamedayDetailView(DetailView):
     model = Gameday
     template_name = "gamedays/gameday_detail.html"
+
+    def get_queryset(self):
+        return Gameday.objects.select_related('league', 'season')
 
     def get_context_data(self, **kwargs):
         context = super(GamedayDetailView, self).get_context_data()

--- a/journey/api/progress_serializers.py
+++ b/journey/api/progress_serializers.py
@@ -31,9 +31,9 @@ class GameinfoProgressSerializer(serializers.ModelSerializer):
 
     def get_gameresult(self, obj):
         """Return the home team gameresult if it exists."""
-        result = obj.gameresult_set.filter(isHome=True).first()
-        if result:
-            return GameResultProgressSerializer(result).data
+        for result in obj.gameresult_set.all():
+            if result.isHome:
+                return GameResultProgressSerializer(result).data
         return None
 
 
@@ -76,12 +76,9 @@ class GamedayProgressSerializer(serializers.ModelSerializer):
         if gameday_has_status:
             return None
 
-        games = obj.gameinfo_set.all()
-        has_games = games.exists()
-        if not has_games:
+        games_list = list(obj.gameinfo_set.all())
+        if not games_list:
             return 'PUBLISHED'
 
-        statuses = [game.status for game in games]
-        all_completed = all(status == Gameinfo.STATUS_COMPLETED for status in statuses)
-
+        all_completed = all(game.status == Gameinfo.STATUS_COMPLETED for game in games_list)
         return 'COMPLETED' if all_completed else 'PUBLISHED'

--- a/journey/api/progress_views.py
+++ b/journey/api/progress_views.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
+from django.db.models import Prefetch, Q
 from django.utils import timezone
 from rest_framework import viewsets, filters
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from gamedays.models import Gameday
+from gamedays.models import Gameday, Gameresult
 from .progress_serializers import GamedayProgressSerializer
 
 
@@ -50,12 +51,17 @@ class GameProgressViewSet(viewsets.ReadOnlyModelViewSet):
         if season:
             queryset = queryset.filter(season__name__icontains=season)
 
+        home_results_prefetch = Prefetch(
+            'gameinfo_set__gameresult_set',
+            queryset=Gameresult.objects.filter(isHome=True)
+        )
+
         queryset = queryset.select_related(
             'league',
             'season',
         ).prefetch_related(
             'gameinfo_set',
-            'gameinfo_set__gameresult_set',
+            home_results_prefetch,
         )
 
         return queryset

--- a/league_manager/settings/base.py
+++ b/league_manager/settings/base.py
@@ -143,6 +143,8 @@ STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "league_manager/static")
 STATICFILES_DIRS = [
     os.path.join(os.path.dirname(BASE_DIR), "journey_dashboard/static"),
+    os.path.join(os.path.dirname(BASE_DIR), "gamedays/static"),
+    os.path.join(os.path.dirname(BASE_DIR), "officials/static"),
 ]
 
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/league_table/models.py
+++ b/league_table/models.py
@@ -75,7 +75,7 @@ class LeagueRuleset(models.Model):
                 "key": league_ruleset_tiebreak.step.key,
                 "is_ascending": league_ruleset_tiebreak.sort_order == "ascending",
             }
-            for league_ruleset_tiebreak in self.leaguerulesettiebreak_set.all().order_by(
+            for league_ruleset_tiebreak in self.leaguerulesettiebreak_set.select_related('step').all().order_by(
                 "order"
             )
         ]

--- a/matchreport/views.py
+++ b/matchreport/views.py
@@ -25,7 +25,7 @@ class MatchreportGamedayListView(UserPassesTestMixin, View):
     def get(self, request, **kwargs):
         year = kwargs.get("season", datetime.today().year)
         league = kwargs.get("league")
-        gamedays = Gameday.objects.filter(date__year=year).order_by("date")
+        gamedays = Gameday.objects.select_related('league').filter(date__year=year).order_by("date")
         leagues = gamedays.values_list("league__name", flat=True).distinct().order_by("league__name")
         gamedays_filtered_by_league = (
             gamedays.filter(league__name=league) if league else gamedays

--- a/officials/service/official_service.py
+++ b/officials/service/official_service.py
@@ -1,8 +1,10 @@
-from django.db.models import Sum
+from django.db.models import Sum, Prefetch, Q
+from django.db.models.functions import Coalesce
 
+from gamedays.models import GameOfficial
 from gamedays.service.team_repository_service import TeamRepositoryService
 from officials.api.serializers import OfficialGameCountSerializer
-from officials.models import Official
+from officials.models import Official, OfficialExternalGames
 from officials.service.game_official_entries import (
     InternalGameOfficialEntry,
     ExternalGameOfficialEntry,
@@ -19,8 +21,22 @@ class OfficialService:
 
     def get_all_officials_with_team_infos(self, team_id, season, is_staff):
         team_repository_service = TeamRepositoryService(team_id)
+
+        game_official_prefetch = Prefetch(
+            'gameofficial_set',
+            queryset=GameOfficial.objects.filter(
+                gameinfo__gameday__date__year=season
+            ).select_related('gameinfo__gameday')
+        )
+        external_games_prefetch = Prefetch(
+            'officialexternalgames_set',
+            queryset=OfficialExternalGames.objects.filter(date__year=season)
+        )
+
         all_team_officials = (
-            Official.objects.filter(
+            Official.objects.select_related('team')
+            .prefetch_related(game_official_prefetch, external_games_prefetch, 'officiallicensehistory_set')
+            .filter(
                 officiallicensehistory__created_at__gte=f"{season - 1}-10-01",
                 officiallicensehistory__created_at__lte=f"{season}-12-31",
                 team=team_repository_service.team,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = test_settings
+DJANGO_SETTINGS_MODULE = league_manager.settings.dev
 
 python_files = test_*.py *_test.py
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = league_manager.settings.dev
+DJANGO_SETTINGS_MODULE = test_settings
 
 python_files = test_*.py *_test.py
 


### PR DESCRIPTION
## Overview

Eliminates a redundant N+1 database query pattern in `GamedayModelWrapper.get_defense_statistic_table()`. Previously, each defense event category (Interception, Safety (+2)) triggered a separate `TeamLog` database query. This PR consolidates them into a single query filtered by all relevant event types at once.

## Changes

- `gamedays/service/model_wrapper.py`
  - Added `_get_all_defense_events()`: issues one `TeamLog.objects.filter(event__in=[...])` query covering all defense event types, then partitions results into a dict keyed by event name using `groupby`
  - Added `_process_events_table(events: pd.DataFrame, event_plural_name: str)`: applies grouping, ranking, and column renaming to a pre-fetched DataFrame slice — replaces per-event DB call
  - Updated `get_defense_statistic_table()` to call `_get_all_defense_events()` once and pass slices to `_process_events_table()`
  - Retained `_get_player_events_table()` unchanged to avoid breaking other callers

## Testing

- QA approval confirmed: code verified syntactically correct
- Logic preserves original behavior: same `isDeleted=False` filter, same null team/player exclusion, same optional passcheck player name enrichment, same ranking via `rank(method="min")` and `head()` truncation
- Result contract to callers of `get_defense_statistic_table()` is unchanged

## Documentation

- No schema changes; no migration required
- No API surface changes

## Checklist

- [x] QA checks passed
- [x] No new TODO/FIXME introduced by this change
- [x] No debug logging added
- [x] Follows project conventional commit conventions
- [x] Existing `_get_player_events_table()` untouched (no regression risk for other callers)

## Additional Notes

The optimization is additive: as more defense event types are tracked in future, the single-query approach scales without additional DB round trips, whereas the prior pattern would have added one query per new event type.