### PR TITLE
fix: optimize database connection pooling for shared hosting

### DIFF
--- a/deployed/docker-compose.demo.yaml
+++ b/deployed/docker-compose.demo.yaml
@@ -67,7 +67,7 @@ services:
   demo-app:
     image: leaguesphere/backend:demo
     container_name: ${COMPOSE_PROJECT_NAME}.demo-app
-    command: gunicorn -b 0.0.0.0:8000 -w 16 --worker-class gthread --threads 2 league_manager.wsgi
+    command: gunicorn -b 0.0.0.0:8000 -w 10 --worker-class gthread --threads 2 league_manager.wsgi
     healthcheck:
       test: ["CMD-SHELL", "curl -A healthcheck -H \"Accept: application/json\" http://localhost:8000/health/?format=json"]
       interval: 15s

--- a/deployed/docker-compose.staging.yaml
+++ b/deployed/docker-compose.staging.yaml
@@ -67,7 +67,7 @@ services:
   staging-app:
     image: leaguesphere/backend:staging
     container_name: ${COMPOSE_PROJECT_NAME}.staging-app
-    command: gunicorn -b 0.0.0.0:8000 -w 16 --worker-class gthread --threads 2 league_manager.wsgi
+    command: gunicorn -b 0.0.0.0:8000 -w 10 --worker-class gthread --threads 2 league_manager.wsgi
     healthcheck:
       test: ["CMD-SHELL", "curl -A healthcheck -H \"Accept: application/json\" http://localhost:8000/health/?format=json"]
       interval: 15s

--- a/deployed/docker-compose.yaml
+++ b/deployed/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
   app:
     image: leaguesphere/backend:latest
     container_name: ${COMPOSE_PROJECT_NAME}.app
-    command: gunicorn -b 0.0.0.0:8000 -w 16 --worker-class gthread --threads 2 league_manager.wsgi
+    command: gunicorn -b 0.0.0.0:8000 -w 10 --worker-class gthread --threads 2 league_manager.wsgi
     labels:
       - traefik.enable=false
       # portainer team

--- a/league_manager/settings/base.py
+++ b/league_manager/settings/base.py
@@ -179,6 +179,7 @@ DATABASES = {
         "PASSWORD": os.environ.get("MYSQL_PWD", "user"),
         "HOST": os.environ.get("MYSQL_HOST", "127.0.0.1"),
         "PORT": os.environ.get("MYSQL_PORT", "3306"),
+        "CONN_MAX_AGE": 300,
         "OPTIONS": {
             "init_command": "SET default_storage_engine=InnoDB;"  # SET foreign_key_checks = 0;',
         },

--- a/league_manager/wsgi_dev.py
+++ b/league_manager/wsgi_dev.py
@@ -1,0 +1,7 @@
+import os
+from django.core.wsgi import get_wsgi_application
+from django.contrib.staticfiles.handlers import StaticFilesHandler
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "league_manager.settings.dev")
+
+application = StaticFilesHandler(get_wsgi_application())


### PR DESCRIPTION
## Summary
- Reduce gunicorn workers from 16 to 10 to lower concurrent database connections
- Set CONN_MAX_AGE=300 to reuse connections for 5 minutes instead of closing after each request

These changes allow the app to work within the external database's 15 max_user_connections limit.

Resolves: max_user_connections errors in production logs

## Test plan
- [x] Staging deployment (v3.22.1) - already deployed
- [ ] Monitor production logs for connection errors
- [ ] Verify request latency is acceptable with 10 workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)