### PR TITLE
fix: remove finalize job check from automerge polling

### DIFF
--- a/.github/workflows/release-please-automerge.yaml
+++ b/.github/workflows/release-please-automerge.yaml
@@ -59,26 +59,12 @@ jobs:
             FAILED=$(echo "$CHECKS_JSON" | jq '[.[] | select(.conclusion == "failure")] | length')
             PENDING=$(echo "$CHECKS_JSON" | jq '[.[] | select(.status != "completed")] | length')
 
-            # Check specifically for finalize workflow
-            FINALIZE=$(echo "$CHECKS_JSON" | jq '.[] | select(.name == "release-please-finalize")' | head -1)
-            FINALIZE_CONCLUSION=$(echo "$FINALIZE" | jq -r '.conclusion // "pending"' 2>/dev/null || echo "pending")
-
             echo "Status: $SUCCESSFUL passed, $FAILED failed, $PENDING pending (total: $TOTAL_CHECKS)"
-            echo "Finalize: $FINALIZE_CONCLUSION"
 
-            # Check if all conditions are met
+            # Proceed when all checks pass (finalize runs asynchronously after merge)
             if [ "$FAILED" -eq 0 ] && [ "$PENDING" -eq 0 ] && [ "$TOTAL_CHECKS" -gt 0 ]; then
-              # If finalize exists and is successful, we're good
-              if [ -n "$FINALIZE" ] && [ "$FINALIZE_CONCLUSION" = "success" ]; then
-                echo "✓ All checks passed and finalize workflow completed successfully!"
-                exit 0
-              # If finalize doesn't exist as a check, other checks passed, proceed
-              elif [ -z "$FINALIZE" ]; then
-                echo "✓ All required checks passed! (Finalize will run asynchronously)"
-                exit 0
-              else
-                echo "⚠ All checks passed, but finalize status is: $FINALIZE_CONCLUSION"
-              fi
+              echo "✓ All checks passed! Proceeding with automerge."
+              exit 0
             fi
 
             # Fail fast if any check failed


### PR DESCRIPTION
## Problem

The automerge workflow times out waiting for the finalize job to complete, even when all CI checks pass. The finalize workflow is designed to run asynchronously after the merge, not before it.

## Solution

Removed the finalize job check from the polling logic. The automerge now:
1. Waits for all CI checks to pass
2. Immediately proceeds with the merge
3. Lets finalize run asynchronously to update version files

## Why This Works

- Finalize updates the PR after the merge anyway
- There's no need to block on it before merging
- Eliminates the 10-minute timeout that was causing failures
- The PR still ends up with the correct version updates from finalize

## Changes

- Simplified polling condition to just check for failed/pending checks
- Removed specific finalize job tracking
- Cleaner logic that matches the intended workflow design