### PR TITLE
chore: reduce gunicorn worker count from 10 to 6

### DIFF
--- a/deployed/docker-compose.demo.yaml
+++ b/deployed/docker-compose.demo.yaml
@@ -67,7 +67,7 @@ services:
   demo-app:
     image: leaguesphere/backend:demo
     container_name: ${COMPOSE_PROJECT_NAME}.demo-app
-    command: gunicorn -b 0.0.0.0:8000 -w 10 --worker-class gthread --threads 2 league_manager.wsgi
+    command: gunicorn -b 0.0.0.0:8000 -w 6 --worker-class gthread --threads 2 league_manager.wsgi
     healthcheck:
       test: ["CMD-SHELL", "curl -A healthcheck -H \"Accept: application/json\" http://localhost:8000/health/?format=json"]
       interval: 15s

--- a/deployed/docker-compose.staging.yaml
+++ b/deployed/docker-compose.staging.yaml
@@ -67,7 +67,7 @@ services:
   staging-app:
     image: leaguesphere/backend:staging
     container_name: ${COMPOSE_PROJECT_NAME}.staging-app
-    command: gunicorn -b 0.0.0.0:8000 -w 10 --worker-class gthread --threads 2 league_manager.wsgi
+    command: gunicorn -b 0.0.0.0:8000 -w 6 --worker-class gthread --threads 2 league_manager.wsgi
     healthcheck:
       test: ["CMD-SHELL", "curl -A healthcheck -H \"Accept: application/json\" http://localhost:8000/health/?format=json"]
       interval: 15s

--- a/deployed/docker-compose.yaml
+++ b/deployed/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
   app:
     image: leaguesphere/backend:latest
     container_name: ${COMPOSE_PROJECT_NAME}.app
-    command: gunicorn -b 0.0.0.0:8000 -w 10 --worker-class gthread --threads 2 league_manager.wsgi
+    command: gunicorn -b 0.0.0.0:8000 -w 6 --worker-class gthread --threads 2 league_manager.wsgi
     labels:
       - traefik.enable=false
       # portainer team


### PR DESCRIPTION
## Summary
Reduces gunicorn worker processes from 10 to 6 across production, staging, and demo deployments to optimize resource utilization and reduce container memory footprint.

## Files Changed
- `deployed/docker-compose.yaml`
- `deployed/docker-compose.demo.yaml`
- `deployed/docker-compose.staging.yaml`

## Test Plan
- [ ] Verify deployments function with reduced worker count
- [ ] Monitor performance on staging before production rollout
- [ ] Check memory usage after deployment