### PR TITLE
fix(gameday-designer): list-canvas scrolls instead of clipping content

### DIFF
--- a/gameday_designer/src/components/ListCanvas.css
+++ b/gameday_designer/src/components/ListCanvas.css
@@ -11,7 +11,10 @@
   background-color: transparent;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  /* x clipped, y scrollable: this flex-clamped canvas must scroll its
+     overflowing content instead of hiding it (was `overflow: hidden`,
+     which clipped ~688px below the fold with no way to reach it). */
+  overflow: hidden auto;
 }
 
 .list-canvas__content {


### PR DESCRIPTION
## Problem
On the gameday designer (e.g. `/gamedays/gameday/design/designer/<id>`) you **cannot scroll** — content below the fold (Team Pool list, fields, etc.) is unreachable.

## Root cause
`gameday_designer/src/components/ListCanvas.css` — `.list-canvas` is flex-clamped to the viewport (`flex: 1; min-height: 0`) and set `overflow: hidden`. The app uses a fixed app-shell (page itself doesn't scroll), and the intended inner scroller is the parent `.list-designer-app__content` (`overflow-auto`) — but because `.list-canvas` *clips* rather than grows, that parent never receives overflowing content, so nothing scrolls. Result: ~688px of content clipped with no scrollbar.

## Fix
`overflow: hidden` → `overflow: hidden auto` (vertical scroll on the canvas; horizontal stays clipped).

## Verification
Reproduced and verified live on `stage.leaguesphere.app` via Chrome DevTools: viewport 1536×786, `.list-canvas` clientHeight 589 vs scrollHeight 1277. Toggling `overflow-y: auto` on that element made it scrollable with `maxScrollTop = 688` (the previously hidden content). This one-line change is exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)