### PR TITLE
feat(db-guard): auto-recover the DB-outage page when the database returns

### DIFF
--- a/league_manager/middleware/db_guard.py
+++ b/league_manager/middleware/db_guard.py
@@ -7,15 +7,17 @@ from django.http import HttpResponse
 
 logger = logging.getLogger(__name__)
 
+
 class DatabaseGuardMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-        self.db_status_cache_key = 'db_connection_status'
+        self.db_status_cache_key = "db_connection_status"
         self.error_html = """<!DOCTYPE html>
 <html lang="de">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="10">
     <title>Datenbank nicht erreichbar - LeagueSphere</title>
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
@@ -43,17 +45,20 @@ class DatabaseGuardMiddleware:
     def __call__(self, request):
         # Determine error URL
         try:
-            error_url = reverse('database-error')
+            error_url = reverse("database-error")
         except:
-            error_url = '/database-error/'
+            error_url = "/database-error/"
 
         # Skip check for static/media files and robots/sitemap
-        if any(request.path.startswith(p) for p in ['/static/', '/media/', '/robots.txt', '/sitemap.xml']):
+        if any(
+            request.path.startswith(p)
+            for p in ["/static/", "/media/", "/robots.txt", "/sitemap.xml"]
+        ):
             return self.get_response(request)
 
         # Check DB status
         db_online = cache.get(self.db_status_cache_key)
-        
+
         if db_online is None:
             # Skip check for the error page itself during the active probe to avoid recursion if something goes wrong
             # but usually we want to know the status.
@@ -74,13 +79,20 @@ class DatabaseGuardMiddleware:
             # If we are on the error page, return the response directly to bypass the rest of the stack
             # (bypasses SessionMiddleware, AuthenticationMiddleware, and DebugToolbarMiddleware)
             if request.path.startswith(error_url):
-                return HttpResponse(self.error_html, content_type="text/html", status=503)
-            
+                return HttpResponse(
+                    self.error_html, content_type="text/html", status=503
+                )
+
             # Allow health check to proceed but with the db_online=False flag set
-            if request.path.startswith('/health/'):
+            if request.path.startswith("/health/"):
                 return self.get_response(request)
-                
+
             # For all other pages, redirect to the error page
             return redirect(error_url)
+
+        # DB is online. If the user is still parked on the error page (e.g. it
+        # auto-refreshed after the database recovered), send them back to the app.
+        if request.path.startswith(error_url):
+            return redirect("/")
 
         return self.get_response(request)

--- a/league_manager/tests/test_db_guard.py
+++ b/league_manager/tests/test_db_guard.py
@@ -4,46 +4,73 @@ from unittest.mock import patch
 from django.db import OperationalError
 from django.core.cache import cache
 
+
 @pytest.fixture(autouse=True)
 def clear_db_status_cache():
     """Clear the DB status cache before and after each test to ensure isolation."""
-    cache.delete('db_connection_status')
+    cache.delete("db_connection_status")
     yield
-    cache.delete('db_connection_status')
+    cache.delete("db_connection_status")
+
 
 @pytest.mark.django_db
 def test_db_guard_redirects_on_failure(client):
     """Test that the middleware redirects to database-error when DB is down."""
     # Ensure cache is clear for test
-    cache.delete('db_connection_status')
-    
-    with patch('django.db.connection.cursor') as mock_cursor:
+    cache.delete("db_connection_status")
+
+    with patch("django.db.connection.cursor") as mock_cursor:
         mock_cursor.side_effect = OperationalError("DB is down")
-        
+
         # Request any page that isn't excluded
-        response = client.get('/')
+        response = client.get("/")
         assert response.status_code == 302
-        assert response.url == reverse('database-error')
+        assert response.url == reverse("database-error")
+
 
 @pytest.mark.django_db
 def test_db_guard_skips_health_check(client):
     """Test that the middleware doesn't redirect health check even if DB is down."""
-    cache.delete('db_connection_status')
+    cache.delete("db_connection_status")
 
-    with patch('django.db.connection.cursor') as mock_cursor:
+    with patch("django.db.connection.cursor") as mock_cursor:
         mock_cursor.side_effect = OperationalError("DB is down")
 
-        response = client.get('/health/')
+        response = client.get("/health/")
         # Should NOT be a redirect
         assert response.status_code == 200
         # Simple health check returns {"status": "healthy"}
         data = response.json()
         assert data["status"] == "healthy"
 
+
 @pytest.mark.django_db
-def test_db_guard_skips_error_page(client):
-    """Test that the middleware doesn't redirect when already on error page."""
-    # We expect 503 now as defined in the static view
-    response = client.get(reverse('database-error'))
+def test_db_guard_shows_error_page_while_db_down(client):
+    """While DB is down, the error page itself returns 503 (no redirect loop)."""
+    # Simulate a known-down DB without breaking the test framework's own DB access.
+    cache.set("db_connection_status", False, 5)
+
+    response = client.get(reverse("database-error"))
     assert response.status_code == 503
-    assert b'Datenbank nicht erreichbar' in response.content
+    assert b"Datenbank nicht erreichbar" in response.content
+
+
+@pytest.mark.django_db
+def test_db_guard_redirects_back_home_when_db_online(client):
+    """When the DB is back online, requesting the error page sends the user back to the app."""
+    # DB is up in the test environment; ensure a fresh probe.
+    cache.delete("db_connection_status")
+
+    response = client.get(reverse("database-error"))
+    assert response.status_code == 302
+    assert response.url == "/"
+
+
+@pytest.mark.django_db
+def test_error_page_auto_refreshes_to_poll_for_recovery(client):
+    """The offline page must auto-poll so it can return to the app once the DB recovers."""
+    cache.set("db_connection_status", False, 5)
+
+    response = client.get(reverse("database-error"))
+    assert response.status_code == 503
+    assert b'http-equiv="refresh"' in response.content

--- a/league_manager/views.py
+++ b/league_manager/views.py
@@ -3,8 +3,10 @@ from django.http import HttpResponse
 from django.views.generic import TemplateView
 from django.conf import settings
 
+
 def homeview(request):
     return render(request, "homeview.html")
+
 
 def database_error_view(request):
     # Static response to avoid any context processors or database-dependent template rendering
@@ -13,6 +15,7 @@ def database_error_view(request):
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="10">
     <title>Datenbank nicht erreichbar - LeagueSphere</title>
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
@@ -38,8 +41,10 @@ def database_error_view(request):
 </html>"""
     return HttpResponse(html, content_type="text/html", status=503)
 
+
 def robots_txt_view(request):
     return render(request, "robots.txt", content_type="text/plain")
+
 
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
@@ -48,6 +53,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import View
 from gamedays.service.team_repository_service import TeamRepositoryService
 
+
 class ClearCacheView(UserPassesTestMixin, View):
     def get(self, request):
         cache.clear()
@@ -55,11 +61,14 @@ class ClearCacheView(UserPassesTestMixin, View):
         if url_has_allowed_host_and_scheme(referer, allowed_hosts={request.get_host()}):
             return redirect(referer)
         return redirect("/")
+
     def test_func(self):
         return self.request.user.is_staff
 
+
 class AllTeamListView(View):
     template_name = "team/all_teams_list.html"
+
     def get(self, request, **kwargs):
         all_teams = TeamRepositoryService.get_all_teams()
         context = {
@@ -68,36 +77,37 @@ class AllTeamListView(View):
         }
         return render(request, self.template_name, context)
 
+
 class DemoInfoView(TemplateView):
-    template_name = 'demo/demo_info.html'
+    template_name = "demo/demo_info.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['demo_mode'] = getattr(settings, 'DEMO_MODE', False)
-        context['demo_credentials'] = [
+        context["demo_mode"] = getattr(settings, "DEMO_MODE", False)
+        context["demo_credentials"] = [
             {
-                'username': 'admin@demo.local',
-                'password': 'DemoAdmin123!',
-                'role': 'Administrator',
-                'description': 'Full system access, user management',
+                "username": "admin@demo.local",
+                "password": "DemoAdmin123!",
+                "role": "Administrator",
+                "description": "Full system access, user management",
             },
             {
-                'username': 'referee@demo.local',
-                'password': 'DemoRef123!',
-                'role': 'Referee',
-                'description': 'Match officiating and scoring',
+                "username": "referee@demo.local",
+                "password": "DemoRef123!",
+                "role": "Referee",
+                "description": "Match officiating and scoring",
             },
             {
-                'username': 'manager@demo.local',
-                'password': 'DemoMgr123!',
-                'role': 'Team Manager',
-                'description': 'Team management and roster control',
+                "username": "manager@demo.local",
+                "password": "DemoMgr123!",
+                "role": "Team Manager",
+                "description": "Team management and roster control",
             },
             {
-                'username': 'user@demo.local',
-                'password': 'DemoUser123!',
-                'role': 'Regular User',
-                'description': 'Viewing standings and league information',
+                "username": "user@demo.local",
+                "password": "DemoUser123!",
+                "role": "Regular User",
+                "description": "Viewing standings and league information",
             },
         ]
         return context


### PR DESCRIPTION
## Summary

Improves the experience during a database outage (including the upcoming LeagueSphere DB cutover window):

- The **"Datenbank nicht erreichbar"** error page now carries `<meta http-equiv="refresh" content="10">`, so it auto-polls every 10 seconds.
- `DatabaseGuardMiddleware` now **redirects the user back to `/`** once the DB is healthy again — a visitor parked on the auto-refreshing error page is bounced home automatically instead of staying stuck.

## Tests

- `test_db_guard_shows_error_page_while_db_down` — 503 while DB down (no redirect loop)
- `test_db_guard_redirects_back_home_when_db_online` — redirect to `/` once DB recovers
- `test_error_page_auto_refreshes_to_poll_for_recovery` — asserts the meta-refresh is present

Also includes a `black` formatting pass on the three touched files (`black --check` passes).

> ⚠️ **Not run locally** — the suite needs the LXC test DB (`./container/spinup_test_db.sh --fresh`); CI will run it on this PR.

## Context

Companion to the DB self-hosting/cutover work — kept as a **separate PR** from the infra/compose changes. Worth landing before the cutover so the maintenance window benefits from the nicer auto-recovering page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)