### PR TITLE
fix(game-progress): serve paginated next URLs over https behind TLS proxy

### DIFF
--- a/container/nginx.conf
+++ b/container/nginx.conf
@@ -2,6 +2,15 @@ upstream django {
  server app:8000;
 }
 
+# Preserve the X-Forwarded-Proto from the upstream proxy (Traefik) that
+# terminates TLS. The nginx<-Traefik hop is plaintext, so $scheme is "http";
+# trusting it would make Django emit insecure http:// absolute URLs (e.g. DRF
+# pagination `next`), which browsers block as mixed content on the HTTPS page.
+map $http_x_forwarded_proto $forwarded_proto {
+ default $http_x_forwarded_proto;
+ ''      $scheme;
+}
+
 server {
  listen 80;
 
@@ -10,7 +19,7 @@ server {
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Proto $forwarded_proto;
  }
 
  location /static/ {

--- a/container/nginx.demo.conf
+++ b/container/nginx.demo.conf
@@ -2,6 +2,15 @@ upstream django {
  server demo-app:8000;
 }
 
+# Preserve the X-Forwarded-Proto from the upstream proxy (Traefik) that
+# terminates TLS. The nginx<-Traefik hop is plaintext, so $scheme is "http";
+# trusting it would make Django emit insecure http:// absolute URLs (e.g. DRF
+# pagination `next`), which browsers block as mixed content on the HTTPS page.
+map $http_x_forwarded_proto $forwarded_proto {
+ default $http_x_forwarded_proto;
+ ''      $scheme;
+}
+
 server {
  listen 80;
 
@@ -10,7 +19,7 @@ server {
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Proto $forwarded_proto;
  }
 
  location /static/ {

--- a/container/nginx.staging.conf
+++ b/container/nginx.staging.conf
@@ -2,6 +2,15 @@ upstream django {
  server staging-app:8000;
 }
 
+# Preserve the X-Forwarded-Proto from the upstream proxy (Traefik) that
+# terminates TLS. The nginx<-Traefik hop is plaintext, so $scheme is "http";
+# trusting it would make Django emit insecure http:// absolute URLs (e.g. DRF
+# pagination `next`), which browsers block as mixed content on the HTTPS page.
+map $http_x_forwarded_proto $forwarded_proto {
+ default $http_x_forwarded_proto;
+ ''      $scheme;
+}
+
 server {
  listen 80;
 
@@ -10,7 +19,7 @@ server {
   proxy_set_header Host $host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Proto $forwarded_proto;
  }
 
  location /static/ {

--- a/journey_dashboard/src/api/__tests__/progressApi.test.ts
+++ b/journey_dashboard/src/api/__tests__/progressApi.test.ts
@@ -78,12 +78,40 @@ describe('progressApi.list', () => {
 
     expect(result.map((g) => g.id)).toEqual([1, 2, 3, 4, 5]);
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    // Page 2+ must be fetched from the server-provided `next` URL.
+    // Page 2+ must be fetched same-origin: the server `next` path is re-based
+    // onto the current page origin (not the raw absolute URL the server sent).
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      'https://leaguesphere.app/api/game-progress/?page=2',
+      `${window.location.origin}/api/game-progress/?page=2`,
       expect.objectContaining({ credentials: 'include' }),
     );
+  });
+
+  it('re-bases an insecure http next URL onto the (https) page origin', async () => {
+    // Regression: behind a TLS-terminating proxy DRF can emit an http:// `next`
+    // URL. Following it verbatim from an https page is blocked as mixed content
+    // ("Failed to fetch"). The client must re-base it onto the page origin.
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [makeGameday(1)],
+          // Insecure scheme + (potentially) different host as reported by proxy.
+          next: 'http://leaguesphere.app/api/game-progress/?page=2',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [makeGameday(2)], next: null }),
+      });
+
+    const result = await progressApi.list();
+
+    expect(result.map((g) => g.id)).toEqual([1, 2]);
+    const secondCallUrl = mockFetch.mock.calls[1][0] as string;
+    // Must be fetched from the page origin, never the insecure http:// URL.
+    expect(secondCallUrl).toBe(`${window.location.origin}/api/game-progress/?page=2`);
+    expect(secondCallUrl.startsWith('http://leaguesphere.app')).toBe(false);
   });
 
   it('handles a non-paginated array response', async () => {

--- a/journey_dashboard/src/api/__tests__/progressApi.test.ts
+++ b/journey_dashboard/src/api/__tests__/progressApi.test.ts
@@ -109,9 +109,10 @@ describe('progressApi.list', () => {
 
     expect(result.map((g) => g.id)).toEqual([1, 2]);
     const secondCallUrl = mockFetch.mock.calls[1][0] as string;
-    // Must be fetched from the page origin, never the insecure http:// URL.
+    // Must be fetched from the page origin, never the cross-origin URL the
+    // proxy reported (compare the parsed host, not a URL substring).
     expect(secondCallUrl).toBe(`${window.location.origin}/api/game-progress/?page=2`);
-    expect(secondCallUrl.startsWith('http://leaguesphere.app')).toBe(false);
+    expect(new URL(secondCallUrl).host).toBe(window.location.host);
   });
 
   it('handles a non-paginated array response', async () => {

--- a/journey_dashboard/src/api/progressApi.ts
+++ b/journey_dashboard/src/api/progressApi.ts
@@ -7,6 +7,16 @@ export interface ProgressApiParams {
   season?: string;
 }
 
+// DRF builds the paginated `next` URL as an absolute URL from the server's view
+// of the request. Behind a TLS-terminating proxy that can come back as http://,
+// which the browser blocks as mixed content on our https page ("Failed to
+// fetch"). Re-base the path+query onto the current page origin so every page is
+// fetched same-origin, regardless of how the proxy reports the scheme/host.
+function toSameOrigin(rawUrl: string): string {
+  const parsed = new URL(rawUrl, window.location.origin);
+  return new URL(parsed.pathname + parsed.search, window.location.origin).toString();
+}
+
 async function fetchPage(url: string): Promise<unknown> {
   const response = await fetch(url, {
     method: 'GET',
@@ -53,7 +63,7 @@ async function list(params?: ProgressApiParams): Promise<GamedayProgress[]> {
     if (data.results) {
       gamedays.push(...data.results);
     }
-    nextUrl = data.next ?? null;
+    nextUrl = data.next ? toSameOrigin(data.next) : null;
   }
 
   return gamedays;

--- a/league_manager/settings/prod.py
+++ b/league_manager/settings/prod.py
@@ -25,3 +25,11 @@ CSRF_TRUSTED_ORIGINS = [
 
 # Sitemap domain for production
 SITEMAP_DOMAIN = "leaguesphere.app"
+
+# Trust X-Forwarded-Proto header from nginx proxy (which forwards Traefik's
+# value) so request.is_secure() is True behind TLS termination and Django emits
+# https:// absolute URLs (DRF pagination, sitemaps, emails, redirects).
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Trust X-Forwarded-Host header from reverse proxy chain (Traefik -> nginx)
+USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
## Problem

The game-progress dashboard fails on **both prod and stage** with:

> Error loading game data: Failed to fetch
> `https://leaguesphere.app/gamedays/progress/`

Browser console shows the real cause:

> Mixed Content: The page at `https://leaguesphere.app/gamedays/progress/` was loaded over HTTPS, but requested an insecure resource `http://leaguesphere.app/api/game-progress/?page=2`. This request has been blocked.

## Root cause

The recent pagination fix (#1406) made `progressApi.list()` follow DRF's absolute `next` URL to fetch page 2+. DRF builds that URL from `request.is_secure()`. In the `Traefik (terminates TLS) → nginx → Django` chain, nginx's `proxy_set_header X-Forwarded-Proto $scheme` **overwrote** the `https` value Traefik forwards with nginx's own plaintext hop (`http`). So Django saw `http`, emitted an `http://` `next`, and the browser blocked it as mixed content.

This hit stage too — even though `stage.py` sets `SECURE_PROXY_SSL_HEADER`, the header *value* arriving was already `http`, making the setting a no-op. Page 1 always worked because the client builds it from `window.location.origin`.

## Fix (defense in depth)

- **nginx (`nginx.conf` / `nginx.staging.conf` / `nginx.demo.conf`)** — preserve the upstream `X-Forwarded-Proto` via a `map`, falling back to `$scheme` for direct access. *True root-cause fix* — corrects all absolute-URL generation (DRF, sitemaps, emails, redirects).
- **`prod.py`** — add `SECURE_PROXY_SSL_HEADER` + `USE_X_FORWARDED_HOST` to match `stage.py` (prod was missing them).
- **`progressApi.ts`** — re-base the `next` path onto `window.location.origin` so pages are fetched same-origin regardless of how the proxy reports scheme/host (client-side hardening) + regression test.

## Verification

- ✅ `journey_dashboard` vitest: 6/6 pass, incl. new test asserting an `http://` `next` is re-based to the page origin.
- ✅ `vite build` clean.
- ⚠️ nginx runtime syntax not validated locally (docker unavailable) — validate on **servyy-test** during deploy.

## Deploy notes

- staging/demo nginx confs are volume-mounted → container restart.
- prod `nginx.conf` is **baked into the image** (`nginx.Dockerfile`) → needs an **image rebuild**, not just a restart.
- Per test-first policy: deploy to servyy-test, confirm `next` returns `https://` and the dashboard loads, then prod with approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)