### PR TITLE
fix: prevent non-integer jersey numbers from crashing gamelog writes (#1465)

### DIFF
--- a/gamedays/service/gamelog.py
+++ b/gamedays/service/gamelog.py
@@ -7,6 +7,10 @@ from gamedays.service.utils import AsJsonEncoder
 
 EXCLUDED_EVENTS = ["Strafe", "Spielzeit", "Auszeit", "First Down"]
 
+# Valid range of TeamLog.player (PositiveSmallIntegerField). Enforced here
+# explicitly because SQLite does not range-check integer columns (#1465).
+PLAYER_MIN, PLAYER_MAX = 0, 32767
+
 
 class GameLogCreator(object):
     def __init__(self, gameinfo, team, event, user, half=1):
@@ -28,7 +32,7 @@ class GameLogCreator(object):
             teamlog.cop = entry.get("name") in ["Turnover", "Interception"]
             teamlog.event = entry.get("name")
             teamlog.input = entry.get("input")
-            teamlog.player = entry.get("player") if entry.get("player") != "" else None
+            teamlog.player = self._coerce_player(entry.get("player"))
             teamlog.value = (
                 self._getValue(entry.get("name")) if teamlog.player is not None else 0
             )
@@ -55,11 +59,24 @@ class GameLogCreator(object):
             return 2
         return 0
 
-    def _get_player(self, value):
-        try:
-            return value if value.isdigit() else None
-        except:
+    @staticmethod
+    def _coerce_player(value):
+        """Sanitise the jersey number that arrives raw from the client (#1465).
+
+        A decimal string such as ``'51.85'`` is truncated to an integer; any
+        value that is not a jersey number storable in ``TeamLog.player``
+        (non-numeric, out of the field's range) is dropped to ``None`` so
+        garbage can never reach the database.
+        """
+        if value is None or value == "":
             return None
+        try:
+            number = int(float(value))
+        except (TypeError, ValueError):
+            return None
+        if not PLAYER_MIN <= number <= PLAYER_MAX:
+            return None
+        return number
 
 
 class GameLog(object):

--- a/gamedays/tests/service/test_gamelog_player_sanitization.py
+++ b/gamedays/tests/service/test_gamelog_player_sanitization.py
@@ -1,0 +1,62 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from gamedays.models import Team, Gameinfo, TeamLog
+from gamedays.service.gamelog import GameLogCreator
+from gamedays.tests.setup_factories.db_setup import DBSetup
+
+
+class TestGamelogPlayerSanitization(TestCase):
+    """Regression for #1465 (gamelog 8262).
+
+    The jersey number arrives raw from the client and was written without
+    validation, so a decimal like ``'51.85'`` ended up in the integer
+    ``player`` column and later blew up on read. The write path must coerce it
+    to a valid integer (truncating) and never persist garbage.
+    """
+
+    def _setup_game(self):
+        DBSetup().g62_status_empty()
+        return Gameinfo.objects.first(), Team.objects.first(), User.objects.first()
+
+    def test_decimal_player_number_is_truncated_to_integer(self):
+        game, team, user = self._setup_game()
+
+        GameLogCreator(
+            game, team, [{"name": "Touchdown", "player": "51.85"}], user
+        ).create()
+
+        teamlog = TeamLog.objects.get(event="Touchdown")
+        assert teamlog.player == 51
+
+    def test_non_numeric_player_number_becomes_none(self):
+        game, team, user = self._setup_game()
+
+        GameLogCreator(
+            game, team, [{"name": "Touchdown", "player": "abc"}], user
+        ).create()
+
+        teamlog = TeamLog.objects.get(event="Touchdown")
+        assert teamlog.player is None
+
+    def test_valid_player_number_is_kept(self):
+        game, team, user = self._setup_game()
+
+        GameLogCreator(
+            game, team, [{"name": "Touchdown", "player": "19"}], user
+        ).create()
+
+        teamlog = TeamLog.objects.get(event="Touchdown")
+        assert teamlog.player == 19
+
+    def test_out_of_range_player_number_becomes_none(self):
+        game, team, user = self._setup_game()
+
+        # 99999 > PositiveSmallIntegerField max (32767): not a storable jersey
+        # number, so it is dropped rather than silently persisted invalid.
+        GameLogCreator(
+            game, team, [{"name": "Touchdown", "player": "99999"}], user
+        ).create()
+
+        teamlog = TeamLog.objects.get(event="Touchdown")
+        assert teamlog.player is None

--- a/scorecard/src/components/scorecard/Safety.jsx
+++ b/scorecard/src/components/scorecard/Safety.jsx
@@ -1,6 +1,7 @@
 
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import {digitsOnly} from '../../util/sanitize';
 
 const Safety = (props) => {
   const {update} = props;
@@ -26,12 +27,14 @@ const Safety = (props) => {
               #
             </div>
             <input
-              type='number'
+              type='text'
+              inputMode='numeric'
+              pattern='[0-9]*'
               className='form-control'
               placeholder='Trikotnummer'
               aria-label='number'
               aria-describedby='btnGroupAddon'
-              onChange={(ev) => setPointsInput(ev.target.value)}
+              onChange={(ev) => setPointsInput(digitsOnly(ev.target.value))}
               required
               value={pointsInput}
             />

--- a/scorecard/src/components/scorecard/Touchdown.jsx
+++ b/scorecard/src/components/scorecard/Touchdown.jsx
@@ -1,6 +1,7 @@
 
 import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
+import {digitsOnly} from '../../util/sanitize';
 
  
 const Touchdown = (props) => {
@@ -28,20 +29,20 @@ const Touchdown = (props) => {
   return (
     <><div className="input-group mt-2">
       <div className="input-group-text" id="btnGroupAddon">#TD&nbsp;</div>
-      <input type="number"
+      <input type="text" inputMode="numeric" pattern="[0-9]*"
         className="form-control" placeholder="Trikotnummer TD"
         aria-label="touchdown number" aria-describedby="btnGroupAddon"
-        onChange={(ev) => setTdInput(ev.target.value)} required
+        onChange={(ev) => setTdInput(digitsOnly(ev.target.value))} required
         value={tdInput} />
     </div>
     <div className="row mt-1" role="toolbar" aria-label="PATbar">
       <div className="col-9">
         <div className="input-group">
           <div className="input-group-text" id="btnGroupAddon">#PAT</div>
-          <input type="number"
+          <input type="text" inputMode="numeric" pattern="[0-9]*"
             className="form-control" placeholder="Trikotnummer PAT"
             aria-label="PAT number" aria-describedby="btnGroupAddon"
-            onChange={(ev) => setPatInput(ev.target.value)}
+            onChange={(ev) => setPatInput(digitsOnly(ev.target.value))}
             value={patInput} />
         </div>
       </div>

--- a/scorecard/src/components/scorecard/__tests__/AddPoints.spec.jsx
+++ b/scorecard/src/components/scorecard/__tests__/AddPoints.spec.jsx
@@ -25,7 +25,7 @@ describe('AddPoints component', () => {
     const user = userEvent.setup();
     setup();
     await user.click(screen.getByRole('radio', {name: 'Serie'}));
-    await user.type(screen.getByRole('spinbutton', {name: 'number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'number'}), '19');
     await user.click(screen.getByRole('button', {name: 'Eintrag speichern'}));
   });
   it('should call callback, when input is submitted', async () => {

--- a/scorecard/src/components/scorecard/__tests__/Details.spec.jsx
+++ b/scorecard/src/components/scorecard/__tests__/Details.spec.jsx
@@ -93,8 +93,8 @@ describe('Details component', () => {
     expect(awayButton).toBeChecked();
     expect(screen.getByText('Einträge Gast')).toBeInTheDocument();
     await user.click(screen.getByRole('radio', {name: 'Touchdown'}));
-    await user.type(screen.getByRole('spinbutton', {name: 'touchdown number'}), '19');
-    await user.type(screen.getByRole('spinbutton', {name: 'PAT number'}), '7');
+    await user.type(screen.getByRole('textbox', {name: 'touchdown number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'PAT number'}), '7');
     await user.click(screen.getByRole('button', {name: 'Eintrag speichern'}));
     expect(homeButton).toBeChecked();
     expect(awayButton).not.toBeChecked();
@@ -130,8 +130,8 @@ describe('Details component', () => {
     const user = userEvent.setup();
     setup();
     await user.click(screen.getByRole('radio', {name: 'Touchdown'}));
-    await user.type(screen.getByRole('spinbutton', {name: 'touchdown number'}), '19');
-    await user.type(screen.getByRole('spinbutton', {name: 'PAT number'}), '7');
+    await user.type(screen.getByRole('textbox', {name: 'touchdown number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'PAT number'}), '7');
     await user.click(screen.getByRole('button', {name: 'Eintrag speichern'}));
     expect(apiPost.mock.calls[0][0]).toBe(`/api/gamelog/${GAME_LOG_COMPLETE_GAME.gameId}`);
     expect(apiPost.mock.calls[0][1].half).toBe(2);

--- a/scorecard/src/components/scorecard/__tests__/Safety.spec.jsx
+++ b/scorecard/src/components/scorecard/__tests__/Safety.spec.jsx
@@ -21,7 +21,7 @@ describe('Touchdown component', () => {
   it('should call update function with +1', async () => {
     const user = userEvent.setup();
     setup();
-    await user.type(screen.getByRole('spinbutton', {name: 'number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'number'}), '19');
     await user.click(screen.getByRole('radio', {name: '1'}));
     expect(mockFunc.mock.calls[mockFunc.mock.calls.length-1][0]).toEqual({
       event: [
@@ -30,7 +30,7 @@ describe('Touchdown component', () => {
   it('should call update function with +2', async () => {
     const user = userEvent.setup();
     setup();
-    await user.type(screen.getByRole('spinbutton', {name: 'number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'number'}), '19');
     expect(mockFunc.mock.calls[mockFunc.mock.calls.length-1][0]).toEqual({event: [
       {name: 'Safety (+2)', player: '19'}]});
   });

--- a/scorecard/src/components/scorecard/__tests__/Touchdown.spec.jsx
+++ b/scorecard/src/components/scorecard/__tests__/Touchdown.spec.jsx
@@ -23,8 +23,8 @@ describe('Touchdown component', () => {
   it('should call update function with pat1', async () => {
     const user = userEvent.setup();
     setup();
-    await user.type(screen.getByRole('spinbutton', {name: 'touchdown number'}), '19');
-    await user.type(screen.getByRole('spinbutton', {name: 'PAT number'}), '7');
+    await user.type(screen.getByRole('textbox', {name: 'touchdown number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'PAT number'}), '7');
     expect(mockFunc.mock.calls[mockFunc.mock.calls.length-1][0]).toEqual({
       event: [
         {name: 'Touchdown', player: '19'},
@@ -36,8 +36,8 @@ describe('Touchdown component', () => {
   it('should call update function with pat2', async () => {
     const user = userEvent.setup();
     setup();
-    await user.type(screen.getByRole('spinbutton', {name: 'touchdown number'}), '19');
-    await user.type(screen.getByRole('spinbutton', {name: 'PAT number'}), '7');
+    await user.type(screen.getByRole('textbox', {name: 'touchdown number'}), '19');
+    await user.type(screen.getByRole('textbox', {name: 'PAT number'}), '7');
     await user.click(screen.getByRole('radio', {name: '2'}));
     expect(mockFunc.mock.calls[mockFunc.mock.calls.length-1][0]).toEqual({
       event: [

--- a/scorecard/src/components/scorecard/gameEvent/InputWithNumber.jsx
+++ b/scorecard/src/components/scorecard/gameEvent/InputWithNumber.jsx
@@ -1,6 +1,7 @@
 
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import {digitsOnly} from '../../../util/sanitize';
 
 const InputWithNumber = (props) => {
   const {update, label, isOpponentAction, isRequired=false} = props;
@@ -18,11 +19,13 @@ const InputWithNumber = (props) => {
             #
             </div>
             <input
-              type='number'
+              type='text'
+              inputMode='numeric'
+              pattern='[0-9]*'
               className='form-control'
               placeholder={isRequired ? `${label} - Trikotnummer` : `${label} - Nummer optional`}
               aria-label='number'
-              onChange={(ev) => setPlayerNumber(ev.target.value)}
+              onChange={(ev) => setPlayerNumber(digitsOnly(ev.target.value))}
               value={playerNumber}
               required={isRequired}
             />

--- a/scorecard/src/components/scorecard/gameEvent/Penalty.jsx
+++ b/scorecard/src/components/scorecard/gameEvent/Penalty.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {FaTrashAlt} from 'react-icons/fa';
 import {connect} from 'react-redux';
 import {getPenalties} from '../../../actions/config';
+import {digitsOnly} from '../../../util/sanitize';
 
 const Penalty = (props) => {
   const LIMIT_DISPLAYED_PENALTIES = 5;
@@ -64,12 +65,14 @@ const Penalty = (props) => {
             #
           </div>
           <input
-            type='number'
+            type='text'
+            inputMode='numeric'
+            pattern='[0-9]*'
             className='form-control'
             placeholder='Trikotnummer'
             aria-label='number'
             aria-describedby='penaltyGroup'
-            onChange={(ev) => setPlayerNumber(ev.target.value)}
+            onChange={(ev) => setPlayerNumber(digitsOnly(ev.target.value))}
             required
             value={playerNumber}
           />

--- a/scorecard/src/components/scorecard/gameEvent/__tests__/InputWithNumber.spec.jsx
+++ b/scorecard/src/components/scorecard/gameEvent/__tests__/InputWithNumber.spec.jsx
@@ -33,4 +33,12 @@ describe('InputWithNumber component', () => {
     });
     expect(updateFunc.mock.calls[2][1]).toBeFalsy();
   });
+  it('should not allow a decimal jersey number (#1465)', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.type(screen.getByPlaceholderText('TestLabel - Nummer optional'), '5.5');
+    const lastCall = updateFunc.mock.calls[updateFunc.mock.calls.length - 1][0];
+    expect(lastCall.event[0].player).toBe('55');
+    expect(lastCall.event[0].player).not.toContain('.');
+  });
 });

--- a/scorecard/src/components/scorecard/gameEvent/__tests__/Penalty.spec.jsx
+++ b/scorecard/src/components/scorecard/gameEvent/__tests__/Penalty.spec.jsx
@@ -48,7 +48,7 @@ describe('Penalty component', () => {
     await user.type(screen.getByPlaceholderText('Trikotnummer'), '42');
     await user.type(screen.getByPlaceholderText('Strafe eingeben und auswählen...'), 'ik');
     await user.click(screen.getByText('illegaler Kontakt Defense'));
-    const illegalContactText = screen.getByRole('textbox');
+    const illegalContactText = screen.getByDisplayValue('illegaler Kontakt Defense');
     expect(illegalContactText).toBeInTheDocument();
     const lastMockCall = updateMock.mock.calls.length - 1;
     expect(updateMock.mock.calls[lastMockCall][0]).toEqual({

--- a/scorecard/src/util/__tests__/sanitize.spec.js
+++ b/scorecard/src/util/__tests__/sanitize.spec.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { digitsOnly } from '../sanitize';
+
+describe('digitsOnly', () => {
+  it('keeps a plain integer string', () => {
+    expect(digitsOnly('22')).toBe('22');
+  });
+  it('strips a decimal point so no float can be entered (#1465)', () => {
+    expect(digitsOnly('51.85')).toBe('5185');
+  });
+  it('strips letters and symbols', () => {
+    expect(digitsOnly('1a-2')).toBe('12');
+  });
+  it('returns empty string for null/undefined', () => {
+    expect(digitsOnly(undefined)).toBe('');
+    expect(digitsOnly(null)).toBe('');
+  });
+});

--- a/scorecard/src/util/sanitize.js
+++ b/scorecard/src/util/sanitize.js
@@ -1,0 +1,10 @@
+/**
+ * Keep only the digit characters of a value.
+ *
+ * Used to constrain jersey-number inputs to non-negative integers so a decimal
+ * (e.g. '51.85') can never be entered and later break the backend (#1465).
+ *
+ * @param {*} value raw input value
+ * @return {string} the value with every non-digit character removed
+ */
+export const digitsOnly = (value) => String(value ?? '').replace(/\D/g, '');


### PR DESCRIPTION
Part of #1465 (the gamelog `8262` error). The Bug-1 NA→int fix shipped separately in #1467; this PR is now scoped to **just** the gamelog write hardening.

## The bug
A scorecard client posted a decimal jersey number (`"51.85"`) to `/api/gamelog`. The value is assigned raw to the integer `TeamLog.player` column, and Django's `get_prep_value` does `int("51.85")` → `ValueError: Field 'player' expected a number but got '51.85'`. The **POST 500s** and the play can't be recorded mid-game.

This is a **write-path** failure, not a read of stored bad data — the original issue mislabeled it as `GET` because Django logs only the path, not the method. That mislabeling is why it was "refuted in testing": testing the GET (a pure read) never reproduces it.

## Fix — prevent bad input instead of failing
| Layer | Change |
|-------|--------|
| **Client** (prevent entry) | The 4 `player`-feeding scorecard inputs (`InputWithNumber`, `Touchdown` TD+PAT, `Penalty`, `Safety`) are digits-only: `inputMode="numeric"` + a shared `digitsOnly()` sanitiser. A decimal can't be typed or pasted. |
| **Service** (no garbage saved) | `GameLogCreator._coerce_player` truncates `'51.85' → 51`, drops non-numeric / out-of-range to `None` (replaces the dead, never-called `_get_player`). |

## Dropped from the earlier version of this PR
- **Data migration `0036`** — removed. Its premise (decimals were *persisted* and crash on *read*) was disproven: prod is MySQL (enforces integer columns) and the ORM rejects decimals on write, so nothing was ever stored. Verified live: **0 non-integer `player` values across 129,299 rows**.
- **`engine.py` NA→int fix + its test** — removed; already merged in #1467.

## Tests
- Backend: `test_gamelog_player_sanitization` (truncate / non-numeric / valid / out-of-range).
- Frontend: `digitsOnly` unit tests + decimal-rejection component test; existing scorecard specs updated for the `number → text` input role change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
