### PR TITLE
fix: gameday detail 500 on finished games with null scores (#1465)

### DIFF
--- a/gamedays/tests/service/test_gameday_qualify_null_scores.py
+++ b/gamedays/tests/service/test_gameday_qualify_null_scores.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from gamedays.models import Gameinfo, Gameresult
+from gamedays.service.gameday_settings import FINISHED
+from gamedays.service.model_wrapper import GamedayModelWrapper
+from gamedays.tests.setup_factories.db_setup import DBSetup
+from league_table.tests.setup_factories.db_setup_leaguetable import (
+    LEAGUE_TABLE_TEST_RULESET,
+)
+from league_table.tests.setup_factories.factories_leaguetable import (
+    LeagueSeasonConfigFactory,
+)
+
+
+class TestQualifyTableWithNullScores(TestCase):
+    """Regression for #1465.
+
+    On prod, gameday 779 had games marked finished (``beendet``) whose
+    ``Gameresult`` rows still had ``fh``/``sh``/``pa`` NULL. The league-table
+    ranking engine computes ``(pf > pa) & finished`` and casts the result to
+    ``int``; a finished-but-scoreless game leaves ``<NA>`` in that mask, so the
+    cast blew up with ``ValueError: cannot convert NA to integer`` (26x).
+    """
+
+    @patch("league_table.service.datatypes.LeagueConfigRuleset.from_ruleset")
+    def test_get_qualify_table_when_finished_game_has_null_scores(
+        self, mock_from_ruleset
+    ):
+        mock_from_ruleset.return_value = LEAGUE_TABLE_TEST_RULESET
+        gameday = DBSetup().create_main_round_gameday(status=FINISHED)
+        LeagueSeasonConfigFactory(league=gameday.league, season=gameday.season)
+        # One finished game whose scores were never entered (inconsistent data).
+        scoreless = Gameinfo.objects.filter(gameday=gameday).first()
+        Gameresult.objects.filter(gameinfo=scoreless).update(
+            fh=None, sh=None, pa=None
+        )
+
+        gmw = GamedayModelWrapper(gameday.pk)
+
+        qualify_table = gmw.get_qualify_table()  # must not raise
+
+        assert qualify_table is not None

--- a/league_table/service/ranking/engine.py
+++ b/league_table/service/ranking/engine.py
@@ -67,6 +67,12 @@ class TeamStatsEngine:
 
         lp = self.ruleset.league_points
 
+        # A game may be marked finished before its score is entered (issue #1465),
+        # leaving pf/pa NULL. Treat a missing score as 0 so the win/draw/loss
+        # masks stay boolean instead of <NA>, which cannot be cast to int.
+        df[PF] = df[PF].fillna(0)
+        df[PA] = df[PA].fillna(0)
+
         finished_mask = df[STATUS] == FINISHED
         win_mask = (df[PF] > df[PA]) & finished_mask
         draw_mask = (df[PF] == df[PA]) & finished_mask


### PR DESCRIPTION
Part of #1465 — **bug #1 of 2**, split out to ship the validated fix on its own. The jersey-number hardening (bug #2) is reworked separately in #1466.

## Bug — gameday detail 500: `cannot convert NA to integer` (26× on prod)
A game marked **finished (`beendet`) before its score is entered** leaves `pf`/`pa` NULL. `TeamStatsEngine._compute_team_stats` casts the resulting `<NA>` win/draw/loss mask to `int`, which raises and 500s the gameday detail page.

## Fix
Fill `pf`/`pa` with `0` before building the masks, matching the `fillna(0)` `league_table_service` already applies upstream. A scoreless finished game ranks `0:0` instead of crashing.

```
league_table/service/ranking/engine.py:75  df[WINS] = win_mask.astype(int)  # was raising
```

## Validation
Reproduced the exact error on `GET /gamedays/gameday/779/` against a **fresh clone of prod data on the stage stack**, then confirmed the fix targets that code path. New test `test_gameday_qualify_null_scores.py` covers a qualify table built from null scores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)