### PR TITLE
fix: bound DB connect_timeout so the offline banner renders during a DB outage

### DIFF
--- a/league_manager/settings/base.py
+++ b/league_manager/settings/base.py
@@ -181,7 +181,11 @@ DATABASES = {
         "PORT": os.environ.get("MYSQL_PORT", "3306"),
         "CONN_MAX_AGE": 300,
         "OPTIONS": {
-            "init_command": "SET default_storage_engine=InnoDB;"  # SET foreign_key_checks = 0;',
+            "init_command": "SET default_storage_engine=InnoDB;",  # SET foreign_key_checks = 0;',
+            # Fail fast when the DB host is unreachable/degraded so the
+            # DatabaseGuardMiddleware probe can render the offline banner instead
+            # of hanging until nginx returns a 504.
+            "connect_timeout": 3,
         },
     },
 }

--- a/league_manager/tests/test_db_guard.py
+++ b/league_manager/tests/test_db_guard.py
@@ -1,8 +1,24 @@
 import pytest
+from django.conf import settings
 from django.urls import reverse
 from unittest.mock import patch
 from django.db import OperationalError
 from django.core.cache import cache
+
+
+def test_default_database_connect_timeout_is_bounded():
+    """The DB connection must fail fast so the guard can render the offline page.
+
+    Without a bounded connect_timeout, a degraded/unreachable host makes the
+    guard's `SELECT 1` probe hang until nginx returns a 504, so users never see
+    the "Datenbank nicht erreichbar" banner. The timeout must be short enough to
+    stay well under the upstream proxy timeout.
+    """
+    options = settings.DATABASES["default"].get("OPTIONS", {})
+    connect_timeout = options.get("connect_timeout")
+
+    assert connect_timeout is not None, "default DATABASES OPTIONS must set connect_timeout"
+    assert 0 < connect_timeout <= 5, f"connect_timeout must be short (got {connect_timeout})"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

Prod (`leaguesphere.app`) went effectively down: nginx served **504 upstream timeouts** instead of the app's "Datenbank nicht erreichbar" maintenance banner. Root cause is the external DB host `s207.goserver.host` being degraded — slow (~7s) handshakes and `max_user_connections` exhaustion.

The app *has* a `DatabaseGuardMiddleware` that probes the DB with `SELECT 1` and redirects to an offline banner on failure. But the default MySQL connection had **no `connect_timeout`**, so against a hanging host the probe blocks for the full TCP timeout. gunicorn sync workers saturate, and nginx times out with a 504 **before** the guard can render the banner. The guard only worked for *fast* DB failures (as its unit tests mock), not *slow* ones.

## Fix

Add `connect_timeout: 3` to the default `DATABASES["default"]["OPTIONS"]` in `settings/base.py` (inherited by all environments). The probe now fails fast, so the guard can serve the offline page instead of hanging into a 504.

## Tests

- Added `test_default_database_connect_timeout_is_bounded` asserting a bounded `connect_timeout` is configured (fails without the fix, passes with it).
- Existing `test_db_guard.py` behavior tests unchanged (they require the CI test DB).

## Rollout

Merging to `master` auto-deploys via CI. This is the immediate mitigation so users see the maintenance banner during the ongoing external-DB degradation; the durable fix is the Phase B cutover to the local `leaguesphere.db` container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)