### PR TITLE
fix(ci): run check_migrations against an ephemeral internal DB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,16 +404,33 @@ jobs:
       - attach_workspace:
           at: /tmp
       - run:
-          name: Check Django Migrations
+          name: Check Django migrations against an ephemeral internal DB
           command: |
             docker load -i /tmp/docker-images/backend.tar
-            docker run --rm \
-              -e MYSQL_HOST="$MYSQL_HOST" \
-              -e MYSQL_DB_NAME="$MYSQL_DB_NAME" \
-              -e MYSQL_USER="$MYSQL_USER" \
-              -e MYSQL_PWD="$MYSQL_PWD" \
+            # Ephemeral MariaDB on an internal, CI-only docker network. It is never
+            # published to a host port, so nothing is exposed. The check validates
+            # OUR migrations against OUR schema — decoupled from any real/prod DB.
+            docker network create ls-ci-net || true
+            docker run -d --name ls-ci-db --network ls-ci-net \
+              -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
+              -e MYSQL_DATABASE=ci_check_db \
+              mariadb:latest \
+              --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+            # Wait for the DB to accept connections.
+            for i in $(seq 1 30); do
+              docker exec ls-ci-db mariadb-admin ping -uroot --silent 2>/dev/null && break
+              echo "waiting for ci db ($i)..."; sleep 2
+            done
+            # Run the real backend image against the fresh DB: verifies there are no
+            # missing migrations AND that the full set applies cleanly end-to-end.
+            docker run --rm --network ls-ci-net \
+              -e MYSQL_HOST=ls-ci-db \
+              -e MYSQL_DB_NAME=ci_check_db \
+              -e MYSQL_USER=root \
+              -e MYSQL_PWD="" \
               backend:latest \
-              bash -c "set -e && python manage.py check && python manage.py makemigrations --check --dry-run && python manage.py migrate --plan"
+              bash -c "set -e && python manage.py check && python manage.py makemigrations --check --dry-run && python manage.py migrate --no-input"
+            docker rm -f ls-ci-db || true
 
   test_compose_network:
     docker:


### PR DESCRIPTION
## Problem
`check_migrations` (`.circleci/config.yml`) ran `python manage.py … migrate --plan` against **`$MYSQL_HOST` = the external prod DB**. Two failures:
1. It couples every PR's CI to prod-DB availability — it went **red** the moment the external host degraded (this is what blocked #1491).
2. Post-cutover the prod DB is the **internal-only** `leaguesphere.db` container, unreachable from cloud CI — so it would stay broken.

## Fix
Run the check against a **throwaway MariaDB on an internal, CI-only docker network** — never published to a host port, nothing exposed — and do a real `migrate --no-input` on the fresh DB. This proves our migrations have **no drift** and **apply cleanly end-to-end**, decoupled from any real/prod DB. Uses the same ephemeral-DB pattern the `python` job already relies on.

## Why this is sufficient
The "migrations actually run on the final prod DB" guarantee already happens at **deploy time, in-network**: `container/entrypoint.sh` runs `migrate --no-input` when `RUN_MIGRATIONS=true` and aborts startup on failure. Pre-merge CI only needs to validate the migrations themselves — which a fresh internal DB does — so nothing needs to reach, or expose, the protected container DB.

## Validation
`circleci config validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)