### PR TITLE
fix(frontend): treat maintenance mode as healthy in www healthcheck

### DIFF
--- a/container/healthcheck.sh
+++ b/container/healthcheck.sh
@@ -6,6 +6,22 @@ ORIGIN="${FRONTEND_URL:-https://leaguesphere.app}"
 
 # 0. Check if service is up
 UP_STATUS=$(curl -A healthcheck-status -s -o /dev/null -w "%{http_code}" "$URL")
+
+# Maintenance mode: the app redirects all real routes to /maintenance/. The
+# service is up and serving correctly, so report healthy and skip the deep
+# login flow below (which cannot pass while maintenance is active). Without this
+# the container is marked unhealthy during maintenance and the reverse proxy
+# stops routing to it.
+if [ "$UP_STATUS" -eq 302 ]; then
+  REDIRECT=$(curl -A healthcheck-status -s -o /dev/null -w "%{redirect_url}" "$URL")
+  case "$REDIRECT" in
+    */maintenance/*)
+      echo "Maintenance mode active (status=302 -> $REDIRECT) — healthy"
+      exit 0
+      ;;
+  esac
+fi
+
 if [ "$UP_STATUS" -ne 200 ]; then
   echo "Service not responding properly (status=$UP_STATUS)"
   exit 1


### PR DESCRIPTION
## Problem (live incident)
During maintenance mode the app redirects every real route — including `/login/` — to `/maintenance/` (302). The `www` healthcheck (`container/healthcheck.sh`) does a full login flow against `/login/` expecting **200**, so it fails → the `www` container is marked **unhealthy** → Traefik stops routing to it → the public site returns **404** instead of the maintenance page.

## Fix
Short-circuit the healthcheck to **healthy** when `/login/` redirects to `/maintenance/` — the service is up and correctly serving the maintenance page. Normal-mode behavior is unchanged: when not in maintenance the deep CSRF login check still runs.

## Verification
Ran the modified script inside the live `www` container while maintenance is active:
```
Maintenance mode active (status=302 -> http://localhost/maintenance/) — healthy
exit_code=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)