### PR TITLE
ci: move prod migrations from CircleCI to Watchtower re-pull

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,25 +84,6 @@ commands:
               docker push << parameters.registry_image_name >>:<< parameters.extra_tag >>
             fi
 
-  run_migrations_cmd:
-    parameters:
-      image_name:
-        type: string
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Run Django Migrations
-          command: |
-            docker load -i /tmp/docker-images/<< parameters.image_name >>.tar
-            docker run --rm \
-              -e MYSQL_HOST="$MYSQL_HOST" \
-              -e MYSQL_DB_NAME="$MYSQL_DB_NAME" \
-              -e MYSQL_USER="$MYSQL_USER" \
-              -e MYSQL_PWD="$MYSQL_PWD" \
-              << parameters.image_name >>:latest \
-              bash -c "set -e && python manage.py migrate --noinput"
-
 jobs:
   python:
     docker:
@@ -581,15 +562,6 @@ jobs:
           command: circleci run release update "leaguesphere-prod" --status=FAILED 
           when: on_fail
 
-  run_migrations_production:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - setup_remote_docker:
-          version: 20.10.24
-      - run_migrations_cmd:
-          image_name: backend
-
   promote_to_prerelease:
     docker:
       - image: cimg/base:stable
@@ -768,17 +740,9 @@ workflows:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/
-      - run_migrations_production:
-          context: production
-          requires:
-            - deploy_production
-          filters:
-            tags:
-              only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/
-
       - create_production_release:
           requires:
-            - run_migrations_production
+            - deploy_production
           filters:
             tags:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
## Summary

Moves production database migrations from a dedicated CircleCI job (`run_migrations_production`) to container startup via `entrypoint.sh`, triggered by Watchtower re-pulling the new `backend:latest` image.

## Changes

### `.circleci/config.yml`
- **Removed** `run_migrations_cmd` command definition
- **Removed** `run_migrations_production` job
- **Rewired** `create_production_release` to require `deploy_production` directly (was: `run_migrations_production`)
- **Preserved** `check_migrations` job — remains the CI migration gate against an ephemeral MariaDB

## New deploy flow

```
merge/tag → CI builds + pushes leaguesphere/backend:latest
          → watchtower-prod re-pulls → recreates leaguesphere.app
          → entrypoint.sh: migrate (RUN_MIGRATIONS=true) against local leaguesphere.db
          → gunicorn starts → app healthcheck passes
```

## Why

- The old `run_migrations_production` job reached the prod DB over the network from CI
- Incompatible with the cutover to the internal-only `leaguesphere.db` container (no published host port — CI cannot reach it)
- Resilient to the external-DB DDoS

## Paired PR

- **servyy-container**: [ci/migrate-on-watchtower](https://github.com/dachrisch/servyy-container/pull/new/ci/migrate-on-watchtower) — enables `RUN_MIGRATIONS=true` in prod's `docker.env.j2`

## Design

[docs/superpowers/specs/2026-07-07-migrations-via-watchtower-repull-design.md](docs/superpowers/specs/2026-07-07-migrations-via-watchtower-repull-design.md)

## Rollout

Code changes are safe to land now. The first live migrate-on-start should be sequenced with the cutover once `leaguesphere.db` is confirmed seeded.