### PR TITLE
fix(db): connect DB container to database network for external service access

### DIFF
--- a/deployed/docker-compose.yaml
+++ b/deployed/docker-compose.yaml
@@ -73,6 +73,7 @@ services:
     env_file: ls.env
     networks:
       - backend
+      - database
     healthcheck:
       test: ["CMD", "sh", "-c", "mariadb -h localhost --skip-ssl -u root -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"]
       interval: 15s


### PR DESCRIPTION
## Summary

The `db` container was only on the `backend` network, making it unreachable from other compose projects via Docker networking.

## Change

Added `database` network to the `db` service in `deployed/docker-compose.yaml`.

## Why

This is needed for leagues-finance to reach `leaguesphere.db` via the shared `leaguesphere_database` Docker network. Without this, the DB container isn't on the network that other services join.

## Deploy

After merge, on the host:
```bash
cd ~/dev/leaguesphere && git pull
docker compose -f deployed/docker-compose.yaml --env-file deployed/ls.env up -d db
```

Or manually connect (temporary):
```bash
docker network connect leaguesphere_database leaguesphere.db
```