### PR TITLE
test(gameday-designer): fix flaky teardown in metadata accordion coverage test

### DIFF
--- a/gameday_designer/src/components/__tests__/GamedayMetadataAccordion-coverage.test.tsx
+++ b/gameday_designer/src/components/__tests__/GamedayMetadataAccordion-coverage.test.tsx
@@ -8,6 +8,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import GamedayMetadataAccordion from "../GamedayMetadataAccordion";
 import { GamedayMetadata } from "../types/flowchart";
 import i18n from "../../i18n/testConfig";
+import { gamedayApi } from "../../api/gamedayApi";
+
+// Mock the network layer so the component's mount effects (listSeasons/
+// listLeagues/getGameday) resolve instead of rejecting. Unmocked axios calls
+// reject asynchronously after the test finishes, and the resulting late
+// console.error lands during vitest worker teardown -> "Closing rpc while
+// onUserConsoleLog was pending" (flaky EnvironmentTeardownError).
+vi.mock("../../api/gamedayApi");
 
 describe('GamedayMetadataAccordion Coverage', () => {
   const mockMetadata: GamedayMetadata = {
@@ -26,6 +34,12 @@ describe('GamedayMetadataAccordion Coverage', () => {
     await i18n.changeLanguage('en');
     vi.clearAllMocks();
     vi.useRealTimers();
+    vi.mocked(gamedayApi.listSeasons).mockResolvedValue([]);
+    vi.mocked(gamedayApi.listLeagues).mockResolvedValue([]);
+    vi.mocked(gamedayApi.getGameday).mockResolvedValue({
+      ...mockMetadata,
+      resource_urls: [],
+    } as never);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Problem

`gameday_designer_js` intermittently fails on master even though all 1088 tests pass, with:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
  → src/components/__tests__/GamedayMetadataAccordion-coverage.test.tsx
```

`GamedayMetadataAccordion` fires `gamedayApi.listSeasons()/listLeagues()/getGameday()` in mount effects. The `-coverage` test rendered the component **without mocking `gamedayApi`** (unlike its sibling `GamedayMetadataAccordion.test.tsx`, which does). Those real axios calls reject *asynchronously after the test finishes*; the resulting `console.error` lands during vitest worker teardown, crashing the worker. Timing-dependent, hence flaky red.

This is independent of #1535/#1536 — reverting never touched it, so the flakiness remains latent on master.

## Fix

Mock `gamedayApi` in the coverage test (mirroring the sibling test) so mount effects resolve cleanly with no async logging — removes the source of the teardown race deterministically.

## Verification

Full `gameday_designer` suite locally: **92 files / 1088 tests pass, zero `Errors`** (previously `Errors 3 errors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)