### PR TITLE
fix(gamedays): block re-publish when a gameday has entered results

### DIFF
--- a/gamedays/api/tests/test_designer_api.py
+++ b/gamedays/api/tests/test_designer_api.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.contrib.auth.models import User
-from gamedays.models import Gameday, GamedayDesignerState
+from gamedays.models import Gameday, Gameinfo, GamedayDesignerState
 from gamedays.tests.setup_factories.db_setup import DBSetup
 
 
@@ -42,6 +42,10 @@ class DesignerAPITest(APITestCase):
         assert metadata["status"] == self.gameday.status
 
     def test_publish_gameday(self):
+        # Publishing regenerates the schedule from the designer canvas, so it is
+        # only allowed when no results have been entered yet. The g62 fixture ships
+        # with scored games, so start this happy-path check from a clean slate.
+        Gameinfo.objects.filter(gameday=self.gameday).delete()
         self.gameday.status = Gameday.STATUS_DRAFT
         self.gameday.save()
         url = f"/api/gamedays/{self.gameday.id}/publish/"

--- a/gamedays/api/tests/test_publish_creates_gameinfos.py
+++ b/gamedays/api/tests/test_publish_creates_gameinfos.py
@@ -184,6 +184,40 @@ class TestPublishCreatesGameinfos:
         assert response.status_code == 200
         assert Gameinfo.objects.filter(gameday=self.gameday).count() == 0
 
+    def test_republish_blocked_when_results_already_entered(self):
+        """Re-publishing a gameday that already has entered scores must be refused
+        and must NOT delete the existing games/results.
+
+        Regression guard: gd874 lost all entered results because unlock + re-publish
+        ran CanvasPublishService, which deletes every Gameinfo (CASCADE to Gameresult).
+        """
+        GamedayDesignerState.objects.create(
+            gameday=self.gameday, state_data=MINIMAL_CANVAS_STATE
+        )
+        # First publish → 1 Gameinfo + 2 Gameresults (no scores yet)
+        assert self._publish().status_code == 200
+        gi = Gameinfo.objects.get(gameday=self.gameday)
+
+        # A score gets entered for the played game
+        home = Gameresult.objects.get(gameinfo=gi, isHome=True)
+        home.fh, home.sh = 3, 4
+        home.save()
+
+        # Unlock back to DRAFT (mirrors the frontend unlock flow)
+        unlock = self.client.patch(
+            f"/api/gamedays/{self.gameday.id}/", {"status": "DRAFT"}, format="json"
+        )
+        assert unlock.status_code == 200
+
+        # Re-publish must be refused because entered results would be destroyed
+        resp = self._publish()
+        assert resp.status_code == 409
+
+        # Existing game and its entered score must be untouched
+        assert Gameinfo.objects.filter(gameday=self.gameday).count() == 1
+        home.refresh_from_db()
+        assert (home.fh, home.sh) == (3, 4)
+
     def test_publish_with_canvas_state_creates_gameinfos(self):
         GamedayDesignerState.objects.create(
             gameday=self.gameday, state_data=MINIMAL_CANVAS_STATE

--- a/gamedays/api/views.py
+++ b/gamedays/api/views.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime
 
 from django.conf import settings
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import condition
 from django.utils.decorators import method_decorator
@@ -33,6 +34,7 @@ from gamedays.models import (
     League,
     Gameresult,
     GamedayDesignerState,
+    TeamLog,
 )
 from gamedays.serializers.game_results import (
     GameResultsUpdateSerializer,
@@ -153,6 +155,27 @@ class GamedayViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(designer_state__isnull=not wants_state)
         return queryset
 
+    @staticmethod
+    def _has_entered_results(gameday) -> bool:
+        """True if the gameday holds played-game data that a re-publish would destroy.
+
+        Publishing runs CanvasPublishService, which deletes every Gameinfo for the
+        gameday (CASCADE to Gameresult / TeamLog / GameSetup). Guarding here prevents
+        an unlock + re-publish from silently wiping entered scores.
+        """
+        has_scores = (
+            Gameresult.objects.filter(gameinfo__gameday=gameday)
+            .filter(Q(fh__isnull=False) | Q(sh__isnull=False) | Q(pa__isnull=False))
+            .exists()
+        )
+        if has_scores:
+            return True
+        if Gameinfo.objects.filter(
+            gameday=gameday, gameFinished__isnull=False
+        ).exists():
+            return True
+        return TeamLog.objects.filter(gameinfo__gameday=gameday).exists()
+
     @action(detail=True, methods=["post"])
     def publish(self, request, pk=None):
         gameday = self.get_object()
@@ -160,6 +183,19 @@ class GamedayViewSet(viewsets.ModelViewSet):
             return Response(
                 {"detail": "Gameday is already published or completed."},
                 status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if self._has_entered_results(gameday):
+            return Response(
+                {
+                    "detail": (
+                        "Cannot re-publish: this gameday already has entered game "
+                        "results. Re-publishing regenerates the schedule and would "
+                        "delete them. Clear the results first if you really need to "
+                        "regenerate."
+                    )
+                },
+                status=status.HTTP_409_CONFLICT,
             )
 
         from django.utils import timezone


### PR DESCRIPTION
## Problem
Publishing a gameday runs `CanvasPublishService.apply()`, which **deletes every `Gameinfo` for the gameday** (`canvas_publish_service.py:38`) — CASCADE to `Gameresult`, `TeamLog`, `GameSetup` — then rebuilds empty games from the designer canvas. The publish view blocks publishing an already-published gameday, but **unlock → DRAFT → re-publish** reaches the destructive path with no guard.

Real incident: gameday **874** had a full matchday of results entered, then a team account unlocked and re-published it from the designer. Every score was deleted and the team assignment reverted to the stale canvas value. No DB/infra fault — purely this in-app path.

## Fix
`publish()` now returns **409 Conflict** when the gameday already holds played-game data — any `Gameresult` score (`fh`/`sh`/`pa`), any `Gameinfo.gameFinished`, or any `TeamLog`. First publish and re-publish of a result-free gameday are unaffected.

## Tests
- New regression test `test_republish_blocked_when_results_already_entered`: publish → enter score → unlock → re-publish must 409 **and** leave the game + score intact.
- Full module green: 15/15 (`DJANGO_SETTINGS_MODULE=league_manager.settings.test_sqlite pytest gamedays/api/tests/test_publish_creates_gameinfos.py`).

## Follow-up (not in this PR)
Frontend should surface the 409 message on the unlock→republish flow (backend now prevents the data loss regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)