### PR TITLE
ci: stop duplicate CircleCI run on release-please branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,30 +609,44 @@ workflows:
     jobs:
       - python:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - e2e:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - scorecard_js:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - liveticker_js:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - passcheck_js:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - gameday_designer_js:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - journey_dashboard_js:
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
 
@@ -641,6 +655,8 @@ workflows:
             - python
             - e2e
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - build_frontend:
@@ -651,6 +667,8 @@ workflows:
             - gameday_designer_js
             - journey_dashboard_js
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
 
@@ -658,12 +676,16 @@ workflows:
           requires:
             - build_backend
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - test_frontend_image:
           requires:
             - build_frontend
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - check_migrations:
@@ -671,6 +693,8 @@ workflows:
           requires:
             - build_backend
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
       - test_compose_network:
@@ -681,6 +705,8 @@ workflows:
             - test_frontend_image
             - check_migrations
           filters:
+            branches:
+              ignore: /^release-please--.*/
             tags:
               only: /.*/
 

--- a/.github/workflows/release-please-finalize.yaml
+++ b/.github/workflows/release-please-finalize.yaml
@@ -76,3 +76,19 @@ jobs:
               exit 1
             fi
           fi
+
+      - name: Trigger CircleCI pipeline
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+        run: |
+          # release-please branches are excluded from CircleCI's automatic
+          # branch-push trigger (see .circleci/config.yml) because release-please
+          # and this workflow each push a commit to the same branch seconds
+          # apart, guaranteeing one wasted full pipeline run per release.
+          # This step explicitly triggers the single run that should actually
+          # be tested: whatever is HEAD on this branch once finalize is done.
+          curl --fail -sS -X POST \
+            "https://circleci.com/api/v2/project/gh/dachrisch/leaguesphere/pipeline" \
+            -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"branch\": \"${{ github.head_ref }}\"}"


### PR DESCRIPTION
## Why

Traced `fix/gameday-list-etag-stale-status` (#1570) through the whole release pipeline and found one fix triggers 8 separate CircleCI pipeline invocations, 3 of which test nothing new. This PR fixes one confirmed, guaranteed-every-release instance of that:

`release-please.yaml` opens/updates the release PR with a commit (e.g. `a35acee8`), then `release-please-finalize.yaml` pushes a second commit (`217b6963`) to the *same* branch ~14 seconds later to sync version files and regenerate `uv.lock`. Both pushes trigger a full 13-job CircleCI pipeline; the first one's jobs land in `error` state seconds after starting because CircleCI's auto-cancel kills it in favor of the second push — confirmed via the GitHub commit-status API on both commits. `release-please-automerge.yaml` only ever looks at the *second* commit's status, so the first run's result is never used by anything.

## What changed

- `.circleci/config.yml`: exclude `release-please--*` branches from the always-on branch-push trigger (`python`, `e2e`, the 5 JS test jobs, both builds, both image tests, `check_migrations`, `test_compose_network`).
- `.github/workflows/release-please-finalize.yaml`: after its push completes (or confirms nothing needed pushing), explicitly trigger one CircleCI pipeline for the branch via the API. This covers the branch-push case CircleCI no longer auto-triggers, including the edge case where finalize finds nothing new to commit.

`release-please-automerge.yaml` needs no changes — it already polls combined status by SHA, and the PR #1261 guarantee (never merge before finalize's version files land) is untouched since finalize still runs first and still gates automerge's poll.

## Before merging

This needs a new repo secret: **`CIRCLECI_TOKEN`** (a CircleCI personal or project API token with pipeline-trigger permission on `gh/dachrisch/leaguesphere`). The new "Trigger CircleCI pipeline" step will fail without it.

## Test plan

- [ ] Add `CIRCLECI_TOKEN` secret
- [ ] Merge, then watch the next release-please cycle: confirm only one CircleCI pipeline runs against `release-please--branches--master` (not the current two), and that it still gates automerge correctly
- [ ] Confirm `release-please-automerge.yaml` still waits for and merges only once that single run is green