### PR TITLE
fix(gameday-designer): iterate team colors per team instead of per group (#1575)

### DIFF
--- a/gameday_designer/src/hooks/useTeamPoolState.ts
+++ b/gameday_designer/src/hooks/useTeamPoolState.ts
@@ -7,7 +7,7 @@
  * - Team assignment tracking (usage)
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type {
   FlowNode,
@@ -30,10 +30,16 @@ export function useTeamPoolState(
   /**
    * Add a new global team to the pool.
    */
+  const teamsCountRef = useRef(globalTeams.length);
+  useEffect(() => {
+    teamsCountRef.current = globalTeams.length;
+  }, [globalTeams.length]);
+
   const addGlobalTeam = useCallback(
     (label?: string, groupId?: string | null, databaseId?: number): GlobalTeam => {
       const id = databaseId ? `team-${databaseId}` : `team-${uuidv4()}`;
-      const order = globalTeams.length;
+      const order = teamsCountRef.current;
+      teamsCountRef.current += 1;
       const color = TEAM_COLORS[order % TEAM_COLORS.length];
 
       const newTeam: GlobalTeam = {
@@ -51,7 +57,7 @@ export function useTeamPoolState(
       });
       return newTeam;
     },
-    [globalTeams, setGlobalTeams]
+    [setGlobalTeams]
   );
 
   /**

--- a/gameday_designer/src/utils/flowchartImport.ts
+++ b/gameday_designer/src/utils/flowchartImport.ts
@@ -21,6 +21,7 @@ import {
 } from '../types/flowchart';
 import type { ScheduleJson } from '../types/designer';
 import { parseTeamReference } from './teamReference';
+import { getTeamColor } from './tournamentConstants';
 
 /**
  * Result of the import operation.
@@ -131,11 +132,13 @@ export function importFromScheduleJson(json: unknown): ImportResult {
             const teamId = `team-${uuidv4()}`;
             teamLabelMap.set(label, teamId);
 
+            const currentOrder = teamOrder++;
             const newTeam: GlobalTeam = {
               id: teamId,
               label,
               groupId: null,
-              order: teamOrder++,
+              order: currentOrder,
+              color: getTeamColor(currentOrder),
             };
             globalTeams.push(newTeam);
           }


### PR DESCRIPTION
Fixes #1575

**Two bugs fixed:**

### 1. Stale closure in `useTeamPoolState.ts`
`addGlobalTeam` read `globalTeams.length` from the closure, which was stale when multiple teams were added synchronously in a loop. Every team in the batch got `order=0` and `color=#3498db`.

**Fix:** Replaced with a `useRef` counter synced via `useEffect`, ensuring sequential colors even across synchronous multi-team-add operations.

### 2. Missing color in `flowchartImport.ts`
Teams imported from schedule JSON were created without a `color` field, defaulting to grey in the UI.

**Fix:** Added `color: getTeamColor(currentOrder)` so imported teams get proper palette colors.