### PR TITLE
feat: show real user avatar and username in gameday designer header

### DIFF
--- a/docs/superpowers/plans/2026-07-20-user-avatar.md
+++ b/docs/superpowers/plans/2026-07-20-user-avatar.md
@@ -1,0 +1,525 @@
+# Real User Avatar in Gameday Designer Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic `bi-person-circle` icon and hardcoded "User" label in the Gameday Designer header with the logged-in user's real avatar (if a staff member set one via Django admin) and real username.
+
+**Architecture:** Extend the existing, already-authenticated `ConfigView` (`gameday_designer/views.py`) with `username`/`avatar_url` fields instead of adding a new endpoint — it's already fetched once on app mount and memoized client-side. Add a `useCurrentUser` React hook that reads those fields, and wire it into `AppHeader.tsx` with a fallback to the current icon/label when no avatar is set.
+
+**Tech Stack:** Django REST Framework (backend), React + TypeScript + Vitest (frontend), pytest (backend tests).
+
+## Global Constraints
+
+- Display-only: no self-service avatar upload UI in this feature. `UserProfile.avatar` stays admin-managed.
+- Users without an uploaded avatar keep seeing the existing fallback icon — no initials-avatar generation.
+- No new API endpoint — extend `ConfigView` (`gameday_designer/views.py:585-593`), not `accounts.UserSerializer`.
+- Backend tests require the LXC test DB: `export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1)` (see root `CLAUDE.md`).
+- Frontend commands run from the `gameday_designer/` directory.
+- `black .` (backend) and `npm run eslint` (frontend, zero errors) must pass before considering any task done.
+
+---
+
+### Task 1: Backend — `ConfigView` returns `username` and `avatar_url`
+
+**Files:**
+- Create: `gameday_designer/tests/test_config_view.py`
+- Modify: `gameday_designer/views.py:585-593` (`ConfigView.get`)
+
+**Interfaces:**
+- Consumes: `gamedays.models.UserProfile` (existing model — `user` FK, `avatar` ImageField, both nullable/blank). Existing fixtures from `gameday_designer/tests/conftest.py`: `api_client`, `staff_user`, `association_user`.
+- Produces: `GET /api/designer/config/` now returns `{"mock_teams": bool, "is_staff": bool, "username": str, "avatar_url": str | null}`. Task 2's frontend type must match this shape exactly.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `gameday_designer/tests/test_config_view.py`:
+
+```python
+"""
+Tests for GET /api/designer/config/ (ConfigView).
+"""
+
+import pytest
+from rest_framework import status
+
+from gamedays.models import UserProfile
+
+
+@pytest.mark.django_db
+class TestConfigView:
+    """Test GET /api/designer/config/."""
+
+    def test_anonymous_cannot_get_config(self, api_client):
+        response = api_client.get("/api/designer/config/")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_is_staff_true_for_staff_user(self, api_client, staff_user):
+        api_client.force_authenticate(user=staff_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_staff"] is True
+
+    def test_is_staff_false_for_regular_user(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_staff"] is False
+
+    def test_mock_teams_defaults_to_false(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["mock_teams"] is False
+
+    def test_username_matches_authenticated_user(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["username"] == association_user.username
+
+    def test_avatar_url_is_none_when_user_has_no_profile(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["avatar_url"] is None
+
+    def test_avatar_url_is_none_when_profile_has_no_avatar_file(self, api_client, association_user):
+        UserProfile.objects.create(user=association_user)
+        api_client.force_authenticate(user=association_user)
+
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["avatar_url"] is None
+
+    def test_avatar_url_returns_file_url_when_avatar_is_set(self, api_client, association_user):
+        profile = UserProfile.objects.create(user=association_user)
+        profile.avatar.name = "media/teammanager/avatars/test-avatar.png"
+        profile.save()
+        api_client.force_authenticate(user=association_user)
+
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["avatar_url"] == profile.avatar.url
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `export MYSQL_HOST=$(lxc list servyy-test --format json | jq -r '.[0].state.network.eth0.addresses[] | select(.family=="inet") | .address' | head -n 1) && pytest gameday_designer/tests/test_config_view.py -v`
+
+Expected: `test_anonymous_cannot_get_config` and `test_is_staff_true_for_staff_user`/`test_is_staff_false_for_regular_user` PASS (existing behavior); `test_username_matches_authenticated_user` and the three `avatar_url` tests FAIL with `KeyError: 'username'` / `KeyError: 'avatar_url'`.
+
+- [ ] **Step 3: Implement `username`/`avatar_url` in `ConfigView`**
+
+In `gameday_designer/views.py`, replace lines 585-593:
+
+```python
+class ConfigView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        from django.conf import settings
+        from gamedays.models import UserProfile
+
+        avatar_url = None
+        try:
+            profile = UserProfile.objects.get(user=request.user)
+            if profile.avatar:
+                avatar_url = profile.avatar.url
+        except UserProfile.DoesNotExist:
+            pass
+
+        return Response({
+            "mock_teams": getattr(settings, "MOCK_TEAMS", False),
+            "is_staff": bool(request.user and request.user.is_staff),
+            "username": request.user.username,
+            "avatar_url": avatar_url,
+        })
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest gameday_designer/tests/test_config_view.py -v`
+Expected: all 8 tests PASS.
+
+- [ ] **Step 5: Format and commit**
+
+Run: `black gameday_designer/views.py gameday_designer/tests/test_config_view.py`
+
+```bash
+git add gameday_designer/views.py gameday_designer/tests/test_config_view.py
+git commit -m "feat: expose username and avatar_url from ConfigView"
+```
+
+---
+
+### Task 2: Frontend — `designerApi` type + `useCurrentUser` hook
+
+**Files:**
+- Modify: `gameday_designer/src/api/designerApi.ts:33` (field decl), `:274-284` (`getConfig`)
+- Modify: `gameday_designer/src/hooks/__tests__/useIsStaff.test.ts` (mock fixtures need the new required fields to type-check)
+- Create: `gameday_designer/src/hooks/useCurrentUser.ts`
+- Create: `gameday_designer/src/hooks/__tests__/useCurrentUser.test.ts`
+
+**Interfaces:**
+- Consumes: `designerApi.getConfig(): Promise<DesignerConfig>` where `DesignerConfig = { mock_teams: boolean; is_staff: boolean; username: string; avatar_url: string | null }` (produced by this task; backend shape from Task 1).
+- Produces: `useCurrentUser(): { username: string; avatarUrl: string | null }`, exported from `gameday_designer/src/hooks/useCurrentUser.ts`. Task 3's `AppHeader.tsx` imports this hook directly (`import { useCurrentUser } from '../../hooks/useCurrentUser';`).
+
+- [ ] **Step 1: Write the failing hook test**
+
+Create `gameday_designer/src/hooks/__tests__/useCurrentUser.test.ts`:
+
+```ts
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { designerApi } from '../../api/designerApi';
+import { useCurrentUser } from '../useCurrentUser';
+
+describe('useCurrentUser', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('returns username and avatarUrl from config when an avatar is set', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'jdoe',
+      avatar_url: '/media/avatars/jdoe.png',
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ username: 'jdoe', avatarUrl: '/media/avatars/jdoe.png' })
+    );
+  });
+
+  it('returns a null avatarUrl when config has no avatar', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'jdoe',
+      avatar_url: null,
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ username: 'jdoe', avatarUrl: null })
+    );
+  });
+
+  it('falls back to empty defaults when the request fails', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ username: '', avatarUrl: null })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `gameday_designer/`): `npx vitest run src/hooks/__tests__/useCurrentUser.test.ts`
+Expected: FAIL — `Failed to resolve import "../useCurrentUser"` (module doesn't exist yet).
+
+- [ ] **Step 3: Extend `designerApi`'s config type**
+
+In `gameday_designer/src/api/designerApi.ts`, add an exported interface near the top (next to `TeamRecord`, after its closing brace around line 26):
+
+```ts
+export interface DesignerConfig {
+  mock_teams: boolean;
+  is_staff: boolean;
+  username: string;
+  avatar_url: string | null;
+}
+```
+
+Replace line 33:
+
+```ts
+  private configPromise: Promise<{ mock_teams: boolean; is_staff: boolean }> | null = null;
+```
+
+with:
+
+```ts
+  private configPromise: Promise<DesignerConfig> | null = null;
+```
+
+Replace lines 274-284 (`getConfig`):
+
+```ts
+  async getConfig(): Promise<DesignerConfig> {
+    if (!this.configPromise) {
+      this.configPromise = this.client.get<DesignerConfig>('/config/')
+        .then(response => response.data)
+        .catch(err => {
+          this.configPromise = null;
+          throw err;
+        });
+    }
+    return this.configPromise;
+  }
+```
+
+- [ ] **Step 4: Update `useIsStaff.test.ts` mocks to satisfy the new required fields**
+
+In `gameday_designer/src/hooks/__tests__/useIsStaff.test.ts`, replace both `mockResolvedValue` calls:
+
+```ts
+  it('returns true when config.is_staff is true', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: true,
+      username: 'staff',
+      avatar_url: null,
+    });
+    const { result } = renderHook(() => useIsStaff());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('returns false when config.is_staff is false', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'regular',
+      avatar_url: null,
+    });
+    const { result } = renderHook(() => useIsStaff());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+```
+
+- [ ] **Step 5: Implement `useCurrentUser`**
+
+Create `gameday_designer/src/hooks/useCurrentUser.ts`:
+
+```ts
+import { useEffect, useState } from 'react';
+import { designerApi } from '../api/designerApi';
+
+export interface CurrentUser {
+  username: string;
+  avatarUrl: string | null;
+}
+
+const DEFAULT_CURRENT_USER: CurrentUser = { username: '', avatarUrl: null };
+
+export function useCurrentUser(): CurrentUser {
+  const [currentUser, setCurrentUser] = useState<CurrentUser>(DEFAULT_CURRENT_USER);
+
+  useEffect(() => {
+    designerApi.getConfig()
+      .then(config => setCurrentUser({ username: config.username, avatarUrl: config.avatar_url }))
+      .catch(() => setCurrentUser(DEFAULT_CURRENT_USER));
+  }, []);
+
+  return currentUser;
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx vitest run src/hooks/__tests__/useCurrentUser.test.ts src/hooks/__tests__/useIsStaff.test.ts`
+Expected: all tests PASS (3 in `useCurrentUser.test.ts`, 2 in `useIsStaff.test.ts`).
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `npm run eslint`
+Expected: 0 errors.
+
+```bash
+git add gameday_designer/src/api/designerApi.ts gameday_designer/src/hooks/useCurrentUser.ts gameday_designer/src/hooks/__tests__/useCurrentUser.test.ts gameday_designer/src/hooks/__tests__/useIsStaff.test.ts
+git commit -m "feat: add useCurrentUser hook backed by DesignerConfig"
+```
+
+---
+
+### Task 3: Frontend — wire the avatar into `AppHeader`
+
+**Files:**
+- Modify: `gameday_designer/src/components/layout/AppHeader.tsx`
+- Modify: `gameday_designer/src/components/layout/__tests__/AppHeader.test.tsx`
+
+**Interfaces:**
+- Consumes: `useCurrentUser(): { username: string; avatarUrl: string | null }` from Task 2 (`gameday_designer/src/hooks/useCurrentUser.ts`); `designerApi` from `gameday_designer/src/api/designerApi.ts`.
+- Produces: no new exports — this is the leaf UI change.
+
+- [ ] **Step 1: Update the failing/changing tests first**
+
+Replace the full contents of `gameday_designer/src/components/layout/__tests__/AppHeader.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AppHeader from '../AppHeader';
+import { GamedayProvider } from '../../../context/GamedayContext';
+import { designerApi } from '../../../api/designerApi';
+import i18n from '../../../i18n/testConfig';
+
+// Mock LanguageSelector since it's tested separately
+vi.mock('../../../components/LanguageSelector', () => ({
+  default: () => <div data-testid="language-selector">LanguageSelector</div>,
+}));
+
+describe('AppHeader', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    vi.restoreAllMocks();
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: '',
+      avatar_url: null,
+    });
+  });
+
+  const renderHeader = (path = '/') => {
+    return render(
+      <MemoryRouter initialEntries={[path]}>
+        <GamedayProvider>
+          <Routes>
+            <Route path="*" element={<AppHeader />} />
+          </Routes>
+        </GamedayProvider>
+      </MemoryRouter>
+    );
+  };
+
+  it('renders application title', () => {
+    renderHeader();
+    expect(screen.getByText(/Gameday Designer/i)).toBeInTheDocument();
+  });
+
+  it('renders dashboard title via brand click', () => {
+    renderHeader('/');
+    expect(screen.getByText(/Gameday Designer/i)).toBeInTheDocument();
+  });
+
+  it('renders gameday name when in designer and name is provided via props', () => {
+    renderHeader('/designer/1');
+    expect(screen.getByText(/New Gameday/i)).toBeInTheDocument();
+  });
+
+  it('shows back button only when in designer', () => {
+    renderHeader('/');
+    expect(screen.queryByTitle(/Back to Dashboard/i)).not.toBeInTheDocument();
+
+    renderHeader('/designer/1');
+    expect(screen.getByTitle(/Back to Dashboard/i)).toBeInTheDocument();
+  });
+
+  it('renders language selector', () => {
+    renderHeader();
+    expect(screen.getByTestId('language-selector')).toBeInTheDocument();
+  });
+
+  it('shows the fallback icon and "User" label when no avatar is set', async () => {
+    renderHeader();
+
+    expect(await screen.findByText('User')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-avatar-image')).not.toBeInTheDocument();
+  });
+
+  it('shows the avatar image and real username once loaded', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'jdoe',
+      avatar_url: '/media/avatars/jdoe.png',
+    });
+
+    renderHeader();
+
+    const avatar = await screen.findByTestId('user-avatar-image');
+    expect(avatar).toHaveAttribute('src', '/media/avatars/jdoe.png');
+    await waitFor(() => expect(screen.getByText('jdoe')).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the two new/changed tests fail**
+
+Run (from `gameday_designer/`): `npx vitest run src/components/layout/__tests__/AppHeader.test.tsx`
+Expected: `shows the fallback icon and "User" label when no avatar is set` PASSES already (fallback UI is unchanged so far); `shows the avatar image and real username once loaded` FAILS — `Unable to find an element by: [data-testid="user-avatar-image"]` (component doesn't render an avatar image yet).
+
+- [ ] **Step 3: Wire `useCurrentUser` into `AppHeader`**
+
+In `gameday_designer/src/components/layout/AppHeader.tsx`, add the import after the existing `GamedayContext` import (after line 7):
+
+```tsx
+import { useGamedayContext } from '../../context/GamedayContext';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
+```
+
+Add the hook call after line 17 (`const { gamedayName, ... } = useGamedayContext();`):
+
+```tsx
+  const { gamedayName, onOpenTemplates, toolbarProps, isLocked } = useGamedayContext();
+  const { username, avatarUrl } = useCurrentUser();
+```
+
+Replace lines 86-89:
+
+```tsx
+            <div className="d-flex align-items-center text-light border-start ps-3 ms-1" style={{ height: '24px' }}>
+              <i className="bi bi-person-circle me-2 fs-5"></i>
+              <span className="small fw-medium">{t('ui:label.user')}</span>
+            </div>
+```
+
+with:
+
+```tsx
+            <div className="d-flex align-items-center text-light border-start ps-3 ms-1" style={{ height: '24px' }}>
+              {avatarUrl ? (
+                <img
+                  src={avatarUrl}
+                  alt={username || t('ui:label.user')}
+                  className="rounded-circle me-2"
+                  style={{ width: '20px', height: '20px', objectFit: 'cover' }}
+                  data-testid="user-avatar-image"
+                />
+              ) : (
+                <i className="bi bi-person-circle me-2 fs-5"></i>
+              )}
+              <span className="small fw-medium">{username || t('ui:label.user')}</span>
+            </div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/layout/__tests__/AppHeader.test.tsx`
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Run the full frontend suite and lint**
+
+Run: `npm run test:run`
+Expected: all tests PASS (no regressions in other suites).
+
+Run: `npm run eslint`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gameday_designer/src/components/layout/AppHeader.tsx gameday_designer/src/components/layout/__tests__/AppHeader.test.tsx
+git commit -m "feat: show real user avatar and username in gameday designer header"
+```
+
+---
+
+## Manual Verification
+
+After all three tasks are committed:
+
+1. Deploy to stage per root `CLAUDE.md` (`./container/deploy.sh stage`).
+2. Log into [stage.leaguesphere.app](https://stage.leaguesphere.app) as a user with no `UserProfile.avatar` set — confirm the header still shows the fallback icon and the real username (not "User" once loaded).
+3. In Django admin, upload an avatar image to that user's `UserProfile`.
+4. Reload the Gameday Designer — confirm the header now shows the uploaded avatar image instead of the icon.

--- a/docs/superpowers/specs/2026-07-20-user-avatar-design.md
+++ b/docs/superpowers/specs/2026-07-20-user-avatar-design.md
@@ -1,0 +1,87 @@
+# Design: Real User Avatar in Gameday Designer Header
+
+Date: 2026-07-20
+Branch: `feat/user-avatar`
+
+## Problem
+
+The Gameday Designer header (`gameday_designer/src/components/layout/AppHeader.tsx`) shows a
+generic Bootstrap icon (`bi-person-circle`) and a hardcoded, translated "User" label, regardless
+of who is logged in. This is the only spot in the codebase with a generic user-avatar
+placeholder — confirmed by repo-wide search.
+
+`UserProfile.avatar` (`gamedays/models.py:298-302`) already exists as an `ImageField`
+(`upload_to="media/teammanager/avatars"`), registered in Django admin, with `MEDIA_URL`/
+`MEDIA_ROOT` configured — but nothing serves or displays it today. It's a dead field.
+
+## Scope
+
+Explicitly **display-only**: show the avatar if a staff member has set one via Django admin;
+no self-service upload UI in this pass. Users without an uploaded avatar (the common case today)
+keep seeing the existing fallback icon — no initials-avatar generation.
+
+The real username also replaces the hardcoded "User" label, since we're already fetching
+per-user data for the avatar.
+
+Out of scope: any other app (passcheck, liveticker, scorecard, journey_dashboard) — none of them
+have a generic-avatar placeholder today, so there's nothing to replace there.
+
+## Backend
+
+Extend the existing `ConfigView` (`gameday_designer/views.py:585-593`) rather than adding a new
+endpoint. It's already `IsAuthenticated`-gated, already fetched once on app mount, and its
+response is memoized client-side (`designerApi.getConfig()`), so no new network round trip is
+introduced.
+
+New response shape:
+```json
+{
+  "mock_teams": false,
+  "is_staff": false,
+  "username": "jdoe",
+  "avatar_url": "/media/teammanager/avatars/jdoe.png"
+}
+```
+
+Implementation:
+- `username`: `request.user.username`.
+- `avatar_url`: look up `UserProfile.objects.get(user=request.user)`, wrapped in
+  `try/except UserProfile.DoesNotExist` — mirroring the existing lookup pattern already used
+  in this same file (`ScheduleTemplateViewSet.get_queryset`, ~line 110-118). Return
+  `profile.avatar.url` if the field has a file, else `None`. Same for the "no profile" case.
+
+Rejected alternative: extend `accounts.UserSerializer` (used by the shared
+`/accounts/auth/user/` endpoint). Rejected because that endpoint/serializer is also used by
+scorecard/liveticker's login flow — widening its shape would affect apps that don't need this
+data, for no benefit over extending the endpoint gameday_designer already calls.
+
+## Frontend (`gameday_designer`)
+
+- `src/api/designerApi.ts`: extend `getConfig()`'s return type with `username: string` and
+  `avatar_url: string | null`.
+- New hook `src/hooks/useCurrentUser.ts` (sibling to the existing `useIsStaff.ts`), calling
+  `designerApi.getConfig()` and returning `{ username, avatarUrl }`, defaulting to
+  `{ username: '', avatarUrl: null }` while loading or on fetch error (fails silently — this is
+  a decorative header element, not critical path).
+- `src/components/layout/AppHeader.tsx:86-89`: replace the static icon + hardcoded label with:
+  - `<img>` of `avatarUrl` when set (circular, ~20px, matching the current icon's visual weight),
+    with `alt={username}`.
+  - Fallback to the existing `bi-person-circle` icon when `avatarUrl` is `null`.
+  - Label shows `username`, falling back to the translated `ui:label.user` string when empty
+    (still loading, or fetch failed).
+
+## Testing
+
+Backend — new test file covering `ConfigView` (currently has zero test coverage):
+- No `UserProfile` for the user → `avatar_url: null`.
+- `UserProfile` exists but `avatar` field is empty → `avatar_url: null`.
+- `UserProfile` exists with an avatar file → `avatar_url` is the file's URL.
+- Baseline coverage for the pre-existing `mock_teams`/`is_staff` fields, since the view had none.
+
+Frontend:
+- `useCurrentUser.test.ts` — mock `designerApi.getConfig` (same style as
+  `useIsStaff.test.ts`), assert hook returns parsed `username`/`avatarUrl`, and defaults on
+  error.
+- `AppHeader.test.tsx` — update the "renders user profile placeholder" test to cover both the
+  fallback state (no avatar/username loaded yet → icon + "User" label) and the loaded state
+  (avatar image + real username rendered).

--- a/gameday_designer/src/api/designerApi.ts
+++ b/gameday_designer/src/api/designerApi.ts
@@ -25,12 +25,19 @@ export interface TeamRecord {
   association_name?: string | null;
 }
 
+export interface DesignerConfig {
+  mock_teams: boolean;
+  is_staff: boolean;
+  username: string;
+  avatar_url: string | null;
+}
+
 /**
  * API client class for Gameday Designer backend operations.
  */
 class DesignerApi {
   private client: AxiosInstance;
-  private configPromise: Promise<{ mock_teams: boolean; is_staff: boolean }> | null = null;
+  private configPromise: Promise<DesignerConfig> | null = null;
 
   constructor() {
     this.client = axios.create({
@@ -271,9 +278,9 @@ class DesignerApi {
     return response.data;
   }
 
-  async getConfig(): Promise<{ mock_teams: boolean; is_staff: boolean }> {
+  async getConfig(): Promise<DesignerConfig> {
     if (!this.configPromise) {
-      this.configPromise = this.client.get<{ mock_teams: boolean; is_staff: boolean }>('/config/')
+      this.configPromise = this.client.get<DesignerConfig>('/config/')
         .then(response => response.data)
         .catch(err => {
           this.configPromise = null;

--- a/gameday_designer/src/components/layout/AppHeader.tsx
+++ b/gameday_designer/src/components/layout/AppHeader.tsx
@@ -5,6 +5,7 @@ import { useTypedTranslation } from '../../i18n/useTypedTranslation';
 import LanguageSelector from '../LanguageSelector';
 import FlowToolbar from '../FlowToolbar';
 import { useGamedayContext } from '../../context/GamedayContext';
+import { useCurrentUser } from '../../hooks/useCurrentUser';
 import '../ListDesignerApp.css';
 
 /**
@@ -15,6 +16,7 @@ import '../ListDesignerApp.css';
 const AppHeader: React.FC = () => {
   const { t } = useTypedTranslation(['ui']);
   const { gamedayName, onOpenTemplates, toolbarProps, isLocked } = useGamedayContext();
+  const { username, avatarUrl } = useCurrentUser();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -84,8 +86,18 @@ const AppHeader: React.FC = () => {
             </div>
             
             <div className="d-flex align-items-center text-light border-start ps-3 ms-1" style={{ height: '24px' }}>
-              <i className="bi bi-person-circle me-2 fs-5"></i>
-              <span className="small fw-medium">{t('ui:label.user')}</span>
+              {avatarUrl ? (
+                <img
+                  src={avatarUrl}
+                  alt={username || t('ui:label.user')}
+                  className="rounded-circle me-2"
+                  style={{ width: '20px', height: '20px', objectFit: 'cover' }}
+                  data-testid="user-avatar-image"
+                />
+              ) : (
+                <i className="bi bi-person-circle me-2 fs-5"></i>
+              )}
+              <span className="small fw-medium">{username || t('ui:label.user')}</span>
             </div>
           </Nav>
         </Navbar.Collapse>

--- a/gameday_designer/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/gameday_designer/src/components/layout/__tests__/AppHeader.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import AppHeader from '../AppHeader';
 import { GamedayProvider } from '../../../context/GamedayContext';
+import { designerApi } from '../../../api/designerApi';
 import i18n from '../../../i18n/testConfig';
 
 // Mock LanguageSelector since it's tested separately
@@ -13,6 +14,13 @@ vi.mock('../../../components/LanguageSelector', () => ({
 describe('AppHeader', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('en');
+    vi.restoreAllMocks();
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: '',
+      avatar_url: null,
+    });
   });
 
   const renderHeader = (path = '/') => {
@@ -38,11 +46,6 @@ describe('AppHeader', () => {
   });
 
   it('renders gameday name when in designer and name is provided via props', () => {
-    // Note: In our implementation, we use GamedayContext, so we test that instead.
-    // However, AppHeader currently doesn't have a way to set the context from props in tests easily
-    // without wrapping it in a test component that sets the context.
-    
-    // Test with default placeholder when context is empty
     renderHeader('/designer/1');
     expect(screen.getByText(/New Gameday/i)).toBeInTheDocument();
   });
@@ -60,8 +63,25 @@ describe('AppHeader', () => {
     expect(screen.getByTestId('language-selector')).toBeInTheDocument();
   });
 
-  it('renders user profile placeholder', () => {
+  it('shows the fallback icon and "User" label when no avatar is set', async () => {
     renderHeader();
-    expect(screen.getByText(/User/i)).toBeInTheDocument();
+
+    expect(await screen.findByText('User')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-avatar-image')).not.toBeInTheDocument();
+  });
+
+  it('shows the avatar image and real username once loaded', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'jdoe',
+      avatar_url: '/media/avatars/jdoe.png',
+    });
+
+    renderHeader();
+
+    const avatar = await screen.findByTestId('user-avatar-image');
+    expect(avatar).toHaveAttribute('src', '/media/avatars/jdoe.png');
+    await waitFor(() => expect(screen.getByText('jdoe')).toBeInTheDocument());
   });
 });

--- a/gameday_designer/src/hooks/__tests__/useCurrentUser.test.ts
+++ b/gameday_designer/src/hooks/__tests__/useCurrentUser.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { designerApi } from '../../api/designerApi';
+import { useCurrentUser } from '../useCurrentUser';
+
+describe('useCurrentUser', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('returns username and avatarUrl from config when an avatar is set', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'jdoe',
+      avatar_url: '/media/avatars/jdoe.png',
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ username: 'jdoe', avatarUrl: '/media/avatars/jdoe.png' })
+    );
+  });
+
+  it('returns a null avatarUrl when config has no avatar', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'jdoe',
+      avatar_url: null,
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ username: 'jdoe', avatarUrl: null })
+    );
+  });
+
+  it('falls back to empty defaults when the request fails', async () => {
+    vi.spyOn(designerApi, 'getConfig').mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ username: '', avatarUrl: null })
+    );
+  });
+});

--- a/gameday_designer/src/hooks/__tests__/useIsStaff.test.ts
+++ b/gameday_designer/src/hooks/__tests__/useIsStaff.test.ts
@@ -7,13 +7,23 @@ describe('useIsStaff', () => {
   beforeEach(() => vi.restoreAllMocks());
 
   it('returns true when config.is_staff is true', async () => {
-    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({ mock_teams: false, is_staff: true });
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: true,
+      username: 'staff',
+      avatar_url: null,
+    });
     const { result } = renderHook(() => useIsStaff());
     await waitFor(() => expect(result.current).toBe(true));
   });
 
   it('returns false when config.is_staff is false', async () => {
-    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({ mock_teams: false, is_staff: false });
+    vi.spyOn(designerApi, 'getConfig').mockResolvedValue({
+      mock_teams: false,
+      is_staff: false,
+      username: 'regular',
+      avatar_url: null,
+    });
     const { result } = renderHook(() => useIsStaff());
     await waitFor(() => expect(result.current).toBe(false));
   });

--- a/gameday_designer/src/hooks/useCurrentUser.ts
+++ b/gameday_designer/src/hooks/useCurrentUser.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { designerApi } from '../api/designerApi';
+
+export interface CurrentUser {
+  username: string;
+  avatarUrl: string | null;
+}
+
+const DEFAULT_CURRENT_USER: CurrentUser = { username: '', avatarUrl: null };
+
+export function useCurrentUser(): CurrentUser {
+  const [currentUser, setCurrentUser] = useState<CurrentUser>(DEFAULT_CURRENT_USER);
+
+  useEffect(() => {
+    designerApi.getConfig()
+      .then(config => setCurrentUser({ username: config.username, avatarUrl: config.avatar_url }))
+      .catch(() => setCurrentUser(DEFAULT_CURRENT_USER));
+  }, []);
+
+  return currentUser;
+}

--- a/gameday_designer/tests/test_config_view.py
+++ b/gameday_designer/tests/test_config_view.py
@@ -3,6 +3,7 @@ Tests for GET /api/designer/config/ (ConfigView).
 """
 
 import pytest
+from django.test import override_settings
 from rest_framework import status
 
 from gamedays.models import UserProfile
@@ -31,11 +32,21 @@ class TestConfigView:
         assert response.status_code == status.HTTP_200_OK
         assert response.data["is_staff"] is False
 
-    def test_mock_teams_defaults_to_false(self, api_client, association_user):
+    @override_settings(MOCK_TEAMS=False)
+    def test_mock_teams_reflects_settings_when_false(
+        self, api_client, association_user
+    ):
         api_client.force_authenticate(user=association_user)
         response = api_client.get("/api/designer/config/")
 
         assert response.data["mock_teams"] is False
+
+    @override_settings(MOCK_TEAMS=True)
+    def test_mock_teams_reflects_settings_when_true(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["mock_teams"] is True
 
     def test_username_matches_authenticated_user(self, api_client, association_user):
         api_client.force_authenticate(user=association_user)

--- a/gameday_designer/tests/test_config_view.py
+++ b/gameday_designer/tests/test_config_view.py
@@ -1,0 +1,74 @@
+"""
+Tests for GET /api/designer/config/ (ConfigView).
+"""
+
+import pytest
+from rest_framework import status
+
+from gamedays.models import UserProfile
+
+
+@pytest.mark.django_db
+class TestConfigView:
+    """Test GET /api/designer/config/."""
+
+    def test_anonymous_cannot_get_config(self, api_client):
+        response = api_client.get("/api/designer/config/")
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_is_staff_true_for_staff_user(self, api_client, staff_user):
+        api_client.force_authenticate(user=staff_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_staff"] is True
+
+    def test_is_staff_false_for_regular_user(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_staff"] is False
+
+    def test_mock_teams_defaults_to_false(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["mock_teams"] is False
+
+    def test_username_matches_authenticated_user(self, api_client, association_user):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["username"] == association_user.username
+
+    def test_avatar_url_is_none_when_user_has_no_profile(
+        self, api_client, association_user
+    ):
+        api_client.force_authenticate(user=association_user)
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["avatar_url"] is None
+
+    def test_avatar_url_is_none_when_profile_has_no_avatar_file(
+        self, api_client, association_user
+    ):
+        UserProfile.objects.create(user=association_user)
+        api_client.force_authenticate(user=association_user)
+
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["avatar_url"] is None
+
+    def test_avatar_url_returns_file_url_when_avatar_is_set(
+        self, api_client, association_user
+    ):
+        profile = UserProfile.objects.create(user=association_user)
+        profile.avatar.name = "media/teammanager/avatars/test-avatar.png"
+        profile.save()
+        api_client.force_authenticate(user=association_user)
+
+        response = api_client.get("/api/designer/config/")
+
+        assert response.data["avatar_url"] == profile.avatar.url

--- a/gameday_designer/views.py
+++ b/gameday_designer/views.py
@@ -22,6 +22,7 @@ import logging
 class TemplatePagination(PageNumberPagination):
     page_size = 1000
 
+
 from gamedays.models import Gameday, Team
 from gameday_designer.models import (
     ScheduleTemplate,
@@ -113,7 +114,9 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
 
                 try:
                     profile = UserProfile.objects.get(user=user)
-                    user_association = profile.team.association if profile.team else None
+                    user_association = (
+                        profile.team.association if profile.team else None
+                    )
                 except UserProfile.DoesNotExist:
                     user_association = None
 
@@ -123,13 +126,17 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
                 # Add association templates (restricted to user's association)
                 if user_association:
                     query |= Q(
-                        association=user_association, sharing=ScheduleTemplate.SHARING_ASSOCIATION
+                        association=user_association,
+                        sharing=ScheduleTemplate.SHARING_ASSOCIATION,
                     )
 
             # Support filtering by association if provided in query params
             assoc_id = self.request.query_params.get("association")
             if assoc_id:
-                query |= Q(association_id=assoc_id, sharing=ScheduleTemplate.SHARING_ASSOCIATION)
+                query |= Q(
+                    association_id=assoc_id,
+                    sharing=ScheduleTemplate.SHARING_ASSOCIATION,
+                )
 
             queryset = (
                 ScheduleTemplate.objects.filter(query)
@@ -204,10 +211,10 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
                 gameday=gameday,
                 team_mapping=team_mapping,
                 applied_by=request.user if request.user.is_authenticated else None,
-                start_time=serializer.validated_data['start_time'],
-                game_duration=serializer.validated_data['game_duration'],
-                break_duration=serializer.validated_data['break_duration'],
-                num_fields=serializer.validated_data['num_fields'],
+                start_time=serializer.validated_data["start_time"],
+                game_duration=serializer.validated_data["game_duration"],
+                break_duration=serializer.validated_data["break_duration"],
+                num_fields=serializer.validated_data["num_fields"],
             )
             result = service.apply()
 
@@ -432,7 +439,7 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
 
         applications = TemplateApplication.objects.filter(
             template=template
-        ).select_related('template', 'gameday', 'applied_by')
+        ).select_related("template", "gameday", "applied_by")
         applications_count = applications.count()
 
         # Get 10 most recent applications
@@ -480,7 +487,9 @@ class TeamCreationView(APIView):
             )
         except IntegrityError:
             return Response(
-                {"error": f"Could not create team '{name}': a team with similar name already exists."},
+                {
+                    "error": f"Could not create team '{name}': a team with similar name already exists."
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -540,7 +549,9 @@ class TeamBulkCreationView(APIView):
                 )
             except IntegrityError:
                 return Response(
-                    {"error": f"Could not create team '{name}': a team with similar name already exists."},
+                    {
+                        "error": f"Could not create team '{name}': a team with similar name already exists."
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             teams.append({"id": team.pk, "name": team.name})
@@ -568,18 +579,24 @@ class LeagueTeamsView(APIView):
         if slt:
             teams = slt.teams.select_related("association").all()
         else:
-            teams = Team.objects.exclude(location="dummy").select_related("association").order_by("name")
+            teams = (
+                Team.objects.exclude(location="dummy")
+                .select_related("association")
+                .order_by("name")
+            )
 
-        return Response([
-            {
-                "id": t.pk,
-                "name": t.name,
-                "association_id": t.association_id,
-                "association_abbr": t.association.abbr if t.association else None,
-                "association_name": t.association.name if t.association else None,
-            }
-            for t in teams
-        ])
+        return Response(
+            [
+                {
+                    "id": t.pk,
+                    "name": t.name,
+                    "association_id": t.association_id,
+                    "association_abbr": t.association.abbr if t.association else None,
+                    "association_name": t.association.name if t.association else None,
+                }
+                for t in teams
+            ]
+        )
 
 
 class ConfigView(APIView):
@@ -587,7 +604,21 @@ class ConfigView(APIView):
 
     def get(self, request):
         from django.conf import settings
-        return Response({
-            "mock_teams": getattr(settings, "MOCK_TEAMS", False),
-            "is_staff": bool(request.user and request.user.is_staff),
-        })
+        from gamedays.models import UserProfile
+
+        avatar_url = None
+        try:
+            profile = UserProfile.objects.get(user=request.user)
+            if profile.avatar:
+                avatar_url = profile.avatar.url
+        except UserProfile.DoesNotExist:
+            pass
+
+        return Response(
+            {
+                "mock_teams": getattr(settings, "MOCK_TEAMS", False),
+                "is_staff": bool(request.user and request.user.is_staff),
+                "username": request.user.username,
+                "avatar_url": avatar_url,
+            }
+        )


### PR DESCRIPTION
## Summary
- Extends the existing `GET /api/designer/config/` endpoint (`ConfigView`) to return the logged-in user's `username` and `avatar_url`, sourced from the previously-unused `UserProfile.avatar` field.
- Adds a `useCurrentUser()` hook in the Gameday Designer frontend that consumes the extended config.
- Wires the hook into `AppHeader`, replacing the generic `bi-person-circle` icon and hardcoded "User" label with the real avatar image (when set) and real username, falling back to the existing icon/label otherwise.

Display-only: no self-service avatar upload UI is added — avatars remain admin-managed via Django admin, matching the currently unused `UserProfile.avatar` field's status quo.

Design spec: `docs/superpowers/specs/2026-07-20-user-avatar-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-20-user-avatar.md`

## Test plan
- [x] Backend: `gameday_designer/tests/test_config_view.py` (9/9 passing) — no profile, profile without avatar, profile with avatar, is_staff, mock_teams (both settings values), username.
- [x] Frontend: `useCurrentUser.test.ts`, updated `useIsStaff.test.ts`, updated `AppHeader.test.tsx` — fallback state and loaded-avatar state.
- [x] Full frontend suite: 1107/1107 passing, `npm run eslint` zero errors.
- [x] `black .` clean.
- [ ] Manual verification on stage: confirm fallback icon for a user with no avatar, and the real avatar after uploading one via Django admin (see plan's "Manual Verification" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)