### PR TITLE
fix(gameday_designer): let non-staff users reach template save flow

### DIFF
--- a/gameday_designer/src/components/modals/TemplateLibraryModal.tsx
+++ b/gameday_designer/src/components/modals/TemplateLibraryModal.tsx
@@ -239,11 +239,9 @@ const TemplateLibraryModal: React.FC<TemplateLibraryModalProps> = ({
             <Modal.Header className="bg-dark text-white">
               <Modal.Title><i className="bi bi-book-half me-2"></i>Template Library</Modal.Title>
               <div className="ms-auto d-flex gap-2 align-items-center">
-                {isStaff && (
-                  <Button size="sm" variant="success" onClick={() => setShowSave(true)} data-testid="save-current-as-template-button">
-                    <i className="bi bi-download me-2"></i>Save current as template
-                  </Button>
-                )}
+                <Button size="sm" variant="success" onClick={() => setShowSave(true)} data-testid="save-current-as-template-button">
+                  <i className="bi bi-download me-2"></i>Save current as template
+                </Button>
                 <Button size="sm" variant="outline-light" onClick={handleHide} aria-label="Close" data-testid="close-template-library-button">
                   <i className="bi bi-x-lg"></i>
                 </Button>
@@ -311,6 +309,7 @@ const TemplateLibraryModal: React.FC<TemplateLibraryModalProps> = ({
         show={showSave}
         onHide={() => setShowSave(false)}
         onSave={handleSave}
+        isStaff={isStaff}
       />
 
       <Modal show={showCloneModal} onHide={() => setShowCloneModal(false)} centered>

--- a/gameday_designer/src/components/modals/TemplateLibraryModal/SaveTemplateSheet.tsx
+++ b/gameday_designer/src/components/modals/TemplateLibraryModal/SaveTemplateSheet.tsx
@@ -5,6 +5,7 @@ interface SaveTemplateSheetProps {
   show: boolean;
   onHide: () => void;
   onSave: (data: { name: string; description: string; sharing: 'PRIVATE' | 'ASSOCIATION' | 'GLOBAL' }) => void;
+  isStaff?: boolean;
 }
 
 const SCOPE_OPTIONS = [
@@ -13,11 +14,15 @@ const SCOPE_OPTIONS = [
   { value: 'GLOBAL' as const, icon: <i className="bi bi-globe me-1"></i>, label: 'Global', desc: 'Visible to all users' },
 ];
 
-const SaveTemplateSheet: React.FC<SaveTemplateSheetProps> = ({ show, onHide, onSave }) => {
+const SaveTemplateSheet: React.FC<SaveTemplateSheetProps> = ({ show, onHide, onSave, isStaff = false }) => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [sharing, setSharing] = useState<'PRIVATE' | 'ASSOCIATION' | 'GLOBAL'>('PRIVATE');
   const [validated, setValidated] = useState(false);
+
+  // Non-staff users may only own PRIVATE templates — the backend rejects
+  // ASSOCIATION/GLOBAL sharing from non-staff, so those options aren't offered.
+  const scopeOptions = isStaff ? SCOPE_OPTIONS : SCOPE_OPTIONS.filter(opt => opt.value === 'PRIVATE');
 
   const handleSave = () => {
     setValidated(true);
@@ -64,7 +69,7 @@ const SaveTemplateSheet: React.FC<SaveTemplateSheetProps> = ({ show, onHide, onS
           <Form.Group>
             <Form.Label className="fw-semibold small text-uppercase">Visibility *</Form.Label>
             <div className="d-flex gap-2">
-              {SCOPE_OPTIONS.map(opt => (
+              {scopeOptions.map(opt => (
                 <div
                   key={opt.value}
                   className={`flex-fill border rounded p-2 text-center ${sharing === opt.value ? 'border-primary bg-primary bg-opacity-10' : ''}`}

--- a/gameday_designer/src/components/modals/TemplateLibraryModal/__tests__/SaveTemplateSheet.test.tsx
+++ b/gameday_designer/src/components/modals/TemplateLibraryModal/__tests__/SaveTemplateSheet.test.tsx
@@ -12,7 +12,7 @@ describe('SaveTemplateSheet', () => {
 
   it('calls onSave with name, description and sharing on submit', () => {
     const onSave = vi.fn();
-    render(<SaveTemplateSheet show onHide={vi.fn()} onSave={onSave} />);
+    render(<SaveTemplateSheet show onHide={vi.fn()} onSave={onSave} isStaff={true} />);
     fireEvent.change(screen.getByPlaceholderText(/template name/i), { target: { value: 'My Format' } });
     fireEvent.click(screen.getByTestId('sharing-option-association'));
     fireEvent.click(screen.getByRole('button', { name: /save template/i }));
@@ -28,5 +28,34 @@ describe('SaveTemplateSheet', () => {
     // Backdrop is also in the body
     const backdrop = document.querySelector('.modal-backdrop');
     expect(backdrop).toHaveClass('template-save-backdrop');
+  });
+
+  it('only offers the Personal sharing option for non-staff users', () => {
+    render(<SaveTemplateSheet show onHide={vi.fn()} onSave={vi.fn()} isStaff={false} />);
+    expect(screen.getByTestId('sharing-option-private')).toBeInTheDocument();
+    expect(screen.queryByTestId('sharing-option-association')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sharing-option-global')).not.toBeInTheDocument();
+  });
+
+  it('offers all sharing options for staff users', () => {
+    render(<SaveTemplateSheet show onHide={vi.fn()} onSave={vi.fn()} isStaff={true} />);
+    expect(screen.getByTestId('sharing-option-private')).toBeInTheDocument();
+    expect(screen.getByTestId('sharing-option-association')).toBeInTheDocument();
+    expect(screen.getByTestId('sharing-option-global')).toBeInTheDocument();
+  });
+
+  it('defaults to only Personal when isStaff is not provided', () => {
+    render(<SaveTemplateSheet show onHide={vi.fn()} onSave={vi.fn()} />);
+    expect(screen.getByTestId('sharing-option-private')).toBeInTheDocument();
+    expect(screen.queryByTestId('sharing-option-association')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sharing-option-global')).not.toBeInTheDocument();
+  });
+
+  it('a non-staff user cannot submit a non-PRIVATE sharing value', () => {
+    const onSave = vi.fn();
+    render(<SaveTemplateSheet show onHide={vi.fn()} onSave={onSave} isStaff={false} />);
+    fireEvent.change(screen.getByPlaceholderText(/template name/i), { target: { value: 'My Format' } });
+    fireEvent.click(screen.getByRole('button', { name: /save template/i }));
+    expect(onSave).toHaveBeenCalledWith({ name: 'My Format', description: '', sharing: 'PRIVATE' });
   });
 });

--- a/gameday_designer/src/components/modals/TemplateLibraryModal/__tests__/TemplateLibraryModal.test.tsx
+++ b/gameday_designer/src/components/modals/TemplateLibraryModal/__tests__/TemplateLibraryModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import TemplateLibraryModal from '../../TemplateLibraryModal';
 import { designerApi } from '../../../../api/designerApi';
@@ -31,12 +31,44 @@ describe('TemplateLibraryModal', () => {
     });
   });
 
-  it('hides "Save current as template" button for non-staff', async () => {
+  it('shows "Save current as template" button for non-staff too', async () => {
     vi.mocked(designerApi.getConfig).mockResolvedValue({ mock_teams: false, is_staff: false });
     render(<TemplateLibraryModal show onHide={vi.fn()} gamedayId={1} currentUserId={1} />);
     await waitFor(() => {
       expect(designerApi.getConfig).toHaveBeenCalled();
     });
-    expect(screen.queryByRole('button', { name: /save current/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save current/i })).toBeInTheDocument();
+  });
+
+  it('lets a non-staff user open the save dialog with only Personal selectable', async () => {
+    vi.mocked(designerApi.getConfig).mockResolvedValue({ mock_teams: false, is_staff: false });
+    render(<TemplateLibraryModal show onHide={vi.fn()} gamedayId={1} currentUserId={1} />);
+
+    await waitFor(() => {
+      expect(designerApi.getConfig).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save current/i }));
+
+    expect(await screen.findByText(/save as template/i)).toBeInTheDocument();
+    expect(screen.getByTestId('sharing-option-private')).toBeInTheDocument();
+    expect(screen.queryByTestId('sharing-option-association')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sharing-option-global')).not.toBeInTheDocument();
+  });
+
+  it('lets a staff user open the save dialog with all sharing options selectable', async () => {
+    vi.mocked(designerApi.getConfig).mockResolvedValue({ mock_teams: false, is_staff: true });
+    render(<TemplateLibraryModal show onHide={vi.fn()} gamedayId={1} currentUserId={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save current/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save current/i }));
+
+    expect(await screen.findByText(/save as template/i)).toBeInTheDocument();
+    expect(screen.getByTestId('sharing-option-private')).toBeInTheDocument();
+    expect(screen.getByTestId('sharing-option-association')).toBeInTheDocument();
+    expect(screen.getByTestId('sharing-option-global')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

#1587 (template ownership permissions) and #1598 (onboarding tours) have both merged to master, but neither updated the frontend to expose #1587's relaxed backend permissions: any authenticated user can now own a PRIVATE `ScheduleTemplate`, yet the "Save current as template" button was still hidden behind an `isStaff` check -- a leftover from before #1587, never revisited by either PR. Non-staff users had no UI path to a feature they'd just been granted.

- `TemplateLibraryModal.tsx`: removed the `isStaff &&` gate around the "Save current as template" button -- any authenticated user can now reach the save dialog.
- `SaveTemplateSheet.tsx`: added an `isStaff` prop (threaded from `TemplateLibraryModal`, same pattern as the sibling `TemplatePreview`); non-staff now only see the Personal/PRIVATE sharing option, matching the server-side restriction in `save_from_designer` / `validate_sharing`. Defaults fail-closed (`isStaff = false` -> PRIVATE only).
- `TemplatePreview.tsx`'s separate `isStaff` gate on "Apply to Gameday" (applying a built-in tournament format) is untouched -- that's a different feature, out of scope here.

## Testing

- Added tests for both staff and non-staff cases in `SaveTemplateSheet.test.tsx` and `TemplateLibraryModal.test.tsx`, including that a non-staff submit always sends `sharing: 'PRIVATE'` regardless of what's rendered.
- npm run test:run: 97 files / 1141 tests pass.
- npm run eslint: zero errors.

Found and fixed while manually verifying #1587 + #1598 together in a local demo environment.