### PR TITLE
fix: validate num_teams and num_fields are positive in save_from_designer

### DIFF
--- a/gameday_designer/tests/test_api.py
+++ b/gameday_designer/tests/test_api.py
@@ -853,3 +853,38 @@ class TestTemplateSaveFromDesigner:
         payload = {**self.VALID_PAYLOAD, "num_fields": -1}
         response = api_client.post(self.URL, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_non_integer_num_teams_returns_400(self, api_client, staff_user):
+        """A non-integer num_teams should return 400, not a 500 from a type error."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "num_teams": "4"}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_non_integer_num_fields_returns_400(self, api_client, staff_user):
+        """A non-integer num_fields should return 400, not a 500 from a type error."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "num_fields": 2.5}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_game_duration_too_short_returns_400(self, api_client, staff_user):
+        """game_duration below 30 should return 400, not 500 from the DB constraint."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "game_duration": 10}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_game_duration_too_long_returns_400(self, api_client, staff_user):
+        """game_duration above 120 should return 400, not 500 from the DB constraint."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "game_duration": 200}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_default_game_duration_is_used_when_omitted(self, api_client, staff_user):
+        """Omitting game_duration should fall back to the default of 70, not fail validation."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {k: v for k, v in self.VALID_PAYLOAD.items() if k != "game_duration"}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED

--- a/gameday_designer/tests/test_api.py
+++ b/gameday_designer/tests/test_api.py
@@ -802,3 +802,54 @@ class TestTemplateWriteGating:
     def test_staff_can_create(self, api_client, staff_user):
         api_client.force_authenticate(user=staff_user)
         assert api_client.post(self.URL, self.PAYLOAD, format="json").status_code == 201
+
+
+@pytest.mark.django_db
+class TestTemplateSaveFromDesigner:
+    """Test POST /api/designer/templates/save-from-designer/."""
+
+    URL = "/api/designer/templates/save-from-designer/"
+
+    VALID_PAYLOAD = {
+        "name": "From Designer",
+        "num_teams": 4,
+        "num_fields": 2,
+        "num_groups": 1,
+        "game_duration": 70,
+        "sharing": "PRIVATE",
+        "slots": [],
+    }
+
+    def test_staff_can_save_from_designer(self, api_client, staff_user):
+        """Staff can save a valid template from the designer canvas."""
+        api_client.force_authenticate(user=staff_user)
+        response = api_client.post(self.URL, self.VALID_PAYLOAD, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+
+    def test_zero_num_teams_returns_400(self, api_client, staff_user):
+        """num_teams=0 should return 400, not 500 from DB constraint."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "num_teams": 0}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_negative_num_teams_returns_400(self, api_client, staff_user):
+        """Negative num_teams should return 400."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "num_teams": -1}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_zero_num_fields_returns_400(self, api_client, staff_user):
+        """num_fields=0 should return 400, not 500 from DB constraint."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "num_fields": 0}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_negative_num_fields_returns_400(self, api_client, staff_user):
+        """Negative num_fields should return 400."""
+        api_client.force_authenticate(user=staff_user)
+        payload = {**self.VALID_PAYLOAD, "num_fields": -1}
+        response = api_client.post(self.URL, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/gameday_designer/views.py
+++ b/gameday_designer/views.py
@@ -385,15 +385,25 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
 
         num_teams = data["num_teams"]
         num_fields = data["num_fields"]
+        game_duration = data.get("game_duration", 70)
 
-        if not isinstance(num_teams, int) or num_teams < 1:
+        if isinstance(num_teams, bool) or not isinstance(num_teams, int) or num_teams < 1:
             return Response(
                 {"error": "num_teams must be a positive integer"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        if not isinstance(num_fields, int) or num_fields < 1:
+        if isinstance(num_fields, bool) or not isinstance(num_fields, int) or num_fields < 1:
             return Response(
                 {"error": "num_fields must be a positive integer"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if (
+            isinstance(game_duration, bool)
+            or not isinstance(game_duration, int)
+            or not (30 <= game_duration <= 120)
+        ):
+            return Response(
+                {"error": "game_duration must be an integer between 30 and 120"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -417,7 +427,7 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
             num_teams=num_teams,
             num_fields=num_fields,
             num_groups=data["num_groups"],
-            game_duration=data.get("game_duration", 70),
+            game_duration=game_duration,
             sharing=sharing,
             created_by=request.user if request.user.is_authenticated else None,
             updated_by=request.user if request.user.is_authenticated else None,

--- a/gameday_designer/views.py
+++ b/gameday_designer/views.py
@@ -383,6 +383,20 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
+        num_teams = data["num_teams"]
+        num_fields = data["num_fields"]
+
+        if not isinstance(num_teams, int) or num_teams < 1:
+            return Response(
+                {"error": "num_teams must be a positive integer"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not isinstance(num_fields, int) or num_fields < 1:
+            return Response(
+                {"error": "num_fields must be a positive integer"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         sharing = data.get("sharing", ScheduleTemplate.SHARING_PRIVATE)
         if sharing not in (
             ScheduleTemplate.SHARING_PRIVATE,
@@ -400,8 +414,8 @@ class ScheduleTemplateViewSet(viewsets.ModelViewSet):
         template = ScheduleTemplate.objects.create(
             name=data["name"],
             description=data.get("description", ""),
-            num_teams=data["num_teams"],
-            num_fields=data["num_fields"],
+            num_teams=num_teams,
+            num_fields=num_fields,
             num_groups=data["num_groups"],
             game_duration=data.get("game_duration", 70),
             sharing=sharing,


### PR DESCRIPTION
## Description

`save_from_designer` returned 500 instead of 400 for under-populated schedules because `num_teams`/`num_fields` were not validated before being passed to `ScheduleTemplate.objects.create()`, triggering DB-level `CheckConstraint` violations.

Added explicit validation mirroring the DB constraints to return a clean 400 Bad Request with a descriptive error message.

## Related Issue
Fixes #1603

## Testing
- `test_zero_num_teams_returns_400` — verifies num_teams=0 returns 400
- `test_negative_num_teams_returns_400` — verifies negative num_teams returns 400  
- `test_zero_num_fields_returns_400` — verifies num_fields=0 returns 400
- `test_negative_num_fields_returns_400` — verifies negative num_fields returns 400