### PR TITLE
fix: align frontend field names with backend serializer (#1604)

### DIFF
--- a/gameday_designer/src/components/modals/TemplateLibraryModal/TemplateList.tsx
+++ b/gameday_designer/src/components/modals/TemplateLibraryModal/TemplateList.tsx
@@ -140,7 +140,7 @@ const TemplateList: React.FC<TemplateListProps> = ({ selectedId, onSelect, searc
                     {SCOPE_ICONS[scope]} <span>{t.name}</span>
                     <div className="text-muted" style={{ fontSize: 11 }}>
                       {scope === 'global'
-                        ? `by ${(t as ScheduleTemplate & { created_by_display?: string }).created_by_display ?? 'unknown'}`
+                        ? `by ${t.created_by_username ?? 'unknown'}`
                         : t.created_at?.split('T')[0]}
                     </div>
                   </ListGroup.Item>

--- a/gameday_designer/src/components/modals/TemplateLibraryModal/__tests__/TemplateList.test.tsx
+++ b/gameday_designer/src/components/modals/TemplateLibraryModal/__tests__/TemplateList.test.tsx
@@ -55,4 +55,32 @@ describe('TemplateList', () => {
     screen.getByText('Club Standard').click();
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ type: 'saved', template: expect.objectContaining({ id: 1 }) }));
   });
+
+  it('shows the creator username for global templates', async () => {
+    const mockTemplate = {
+      id: 2, name: 'Community Bracket', sharing: 'GLOBAL' as const,
+      num_teams: 8, num_fields: 4, num_groups: 2, game_duration: 70,
+      association: null, created_by: 5, created_by_username: 'jdoe', updated_by: 5, created_at: '', updated_at: '',
+    };
+    vi.mocked(designerApi.listTemplates).mockImplementation(async (params) => {
+      if (params?.sharing === 'global') return { results: [mockTemplate], count: 1, next: null, previous: null };
+      return mockEmptyResponse;
+    });
+    render(<TemplateList selectedId={null} onSelect={vi.fn()} searchQuery="" filterScope="all" />);
+    await waitFor(() => expect(screen.getByText('by jdoe')).toBeInTheDocument());
+  });
+
+  it('falls back to "unknown" when a global template has no creator username', async () => {
+    const mockTemplate = {
+      id: 3, name: 'Anonymous Bracket', sharing: 'GLOBAL' as const,
+      num_teams: 8, num_fields: 4, num_groups: 2, game_duration: 70,
+      association: null, created_by: null, updated_by: null, created_at: '', updated_at: '',
+    };
+    vi.mocked(designerApi.listTemplates).mockImplementation(async (params) => {
+      if (params?.sharing === 'global') return { results: [mockTemplate], count: 1, next: null, previous: null };
+      return mockEmptyResponse;
+    });
+    render(<TemplateList selectedId={null} onSelect={vi.fn()} searchQuery="" filterScope="all" />);
+    await waitFor(() => expect(screen.getByText('by unknown')).toBeInTheDocument());
+  });
 });

--- a/gameday_designer/src/types/api.ts
+++ b/gameday_designer/src/types/api.ts
@@ -73,11 +73,11 @@ export interface ScheduleTemplate {
   description?: string;
   sharing: 'PRIVATE' | 'ASSOCIATION' | 'GLOBAL';
   association: number | null;
-  association_display?: string;
+  association_name?: string;
   created_by: number | null;
-  created_by_display?: string;
+  created_by_username?: string;
   updated_by: number | null;
-  updated_by_display?: string;
+  updated_by_username?: string;
   created_at: string;
   updated_at: string;
   slots?: TemplateSlot[];


### PR DESCRIPTION
Fixes #1604

Template Library always showed "by unknown" because the frontend
was reading a non-existent `created_by_display` field while the
backend serializer exposes `created_by_username`.

Changes:
- Rename `created_by_display` → `created_by_username` (and similarly for `updated_by_display`/`updated_by_username` and `association_display`/`association_name`) in the `ScheduleTemplate` TypeScript type
- Update `TemplateList` to read `created_by_username` directly

Closes #1604