### PR TITLE
ci: auto-approve production hold on weekdays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,6 +629,44 @@ jobs:
           env:
             GH_TOKEN: ${GITHUB_TOKEN}
 
+  auto_approve_hold_production:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Auto-approve hold_production outside weekends
+          command: |
+            dow=$(date -u +%u) # 1=Mon .. 7=Sun (UTC)
+            if [ "$dow" -ge 6 ]; then
+              echo "Weekend (day $dow, UTC) - leaving hold_production for manual approval"
+              exit 0
+            fi
+            echo "Weekday (day $dow, UTC) - auto-approving hold_production"
+
+            sudo apt-get update -qq && sudo apt-get install -qq -y jq
+
+            approval_request_id=""
+            for i in $(seq 1 30); do
+              approval_request_id=$(curl -sf --header "Circle-Token: ${CIRCLE_API_APPROVE_TOKEN}" \
+                "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job" \
+                | jq -r '.items[] | select(.name == "hold_production") | .approval_request_id // empty')
+              if [ -n "$approval_request_id" ]; then
+                break
+              fi
+              echo "Waiting for hold_production approval request to appear ($i/30)..."
+              sleep 5
+            done
+
+            if [ -z "$approval_request_id" ]; then
+              echo "Could not find hold_production's approval_request_id in workflow ${CIRCLE_WORKFLOW_ID}"
+              exit 1
+            fi
+
+            echo "Approving hold_production (approval_request_id=${approval_request_id})"
+            curl -sf --request POST \
+              --header "Circle-Token: ${CIRCLE_API_APPROVE_TOKEN}" \
+              "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/approve/${approval_request_id}"
+
 workflows:
   version: 2
   build_test_deploy:
@@ -756,7 +794,18 @@ workflows:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/
-      
+      # Auto-approves hold_production via the CircleCI API on weekdays, so
+      # production deploys only require a manual click on weekends.
+      - auto_approve_hold_production:
+          context: production
+          requires:
+            - test_compose_network
+          filters:
+            tags:
+              only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/
+            branches:
+              ignore: /.*/
+
       - deploy_production:
           context: production
           requires:


### PR DESCRIPTION
## Summary
- `hold_production` remains a real manual approval gate, but only actually blocks on weekends.
- New `auto_approve_hold_production` job runs alongside it (same `requires`/`filters`); on weekdays it polls the CircleCI API for `hold_production`'s `approval_request_id` in the current workflow and calls the v2 approve endpoint, so `deploy_production`/`deploy_demo_production` proceed without a manual click Mon-Fri.
- `hold_production`, `deploy_production`, `deploy_demo_production`, and `create_production_release` are unchanged — no changes to the existing job graph or `requires`.

CircleCI has no compile-time day-of-week pipeline value and no per-job `when`/`unless` inside a workflow's `jobs:` list (verified against the real config compiler via `circleci config validate`/`process`), so a static filter-based approach wasn't possible without duplicating the entire ~30-job workflow. The API auto-approve keeps the existing graph untouched.

Requires `CIRCLE_API_APPROVE_TOKEN` in the `production` context (already added).

## Test plan
- [ ] `circleci config validate .circleci/config.yml` passes (done locally)
- [ ] Push a real release tag on a weekday and confirm `auto_approve_hold_production` finds and approves `hold_production` automatically, unblocking `deploy_production`
- [ ] Push a real release tag on a weekend (or temporarily flip the `dow` check) and confirm `hold_production` still blocks for manual approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)