### PR TITLE
fix(gamedays): drop staff/owner gate on game officials endpoint

### DIFF
--- a/gamedays/api/views.py
+++ b/gamedays/api/views.py
@@ -322,7 +322,12 @@ class GamedayRetrieveUpdate(RetrieveUpdateAPIView):
 
 
 class GameOfficialCreateOrUpdateView(RetrieveUpdateAPIView):
-    permission_classes = [IsAuthenticatedOrGamedayOwnerOrStaff]
+    # Deliberately no staff/gameday-author gate here (unlike other mutating
+    # views in this file): officials are assigned on-site by whichever
+    # team/crew is running the scorecard for that specific game, not
+    # necessarily the gameday's staff or author. Bare IsAuthenticatedOrReadOnly
+    # (the DRF default) matches the sibling GameSetupCreateOrUpdateView, which
+    # sets gameStarted via the same "Spiel starten" submit — see #1634.
     serializer_class = GameOfficialSerializer
     queryset = GameOfficial.objects.all()
 
@@ -337,10 +342,7 @@ class GameOfficialCreateOrUpdateView(RetrieveUpdateAPIView):
 
     def update(self, request, *args, **kwargs):
         pk = kwargs.get("pk")
-        gameinfo = get_object_or_404(Gameinfo, pk=pk)
-
-        if not _check_gameday_mutation_permission(request, gameinfo.gameday):
-            return Response({"detail": "You do not have permission to perform this action."}, status=status.HTTP_403_FORBIDDEN)
+        get_object_or_404(Gameinfo, pk=pk)
 
         response_data = []
         for item in request.data:

--- a/gamedays/tests/api/test_views.py
+++ b/gamedays/tests/api/test_views.py
@@ -379,7 +379,13 @@ class TestStandaloneViewPermissions(WebTest):
         )
         assert response.status_code in (401, 403)
 
-    def test_non_staff_non_author_cannot_update_game_officials(self):
+    def test_non_staff_non_author_can_update_game_officials(self):
+        # Officials are assigned on-site by whichever team/crew is running the
+        # scorecard for that game — not necessarily the gameday's staff/author.
+        # See #1634: PR #1596 (fixing #1591, which was about the unrelated
+        # gameday-designer publish/state endpoints) over-applied the
+        # staff-or-author gate to this endpoint too, blocking every non-staff
+        # scorecard operator in production.
         gameday = DBSetup().g62_status_empty()
         gameday.author = DBSetup().create_new_user("go_author")
         gameday.save()
@@ -389,9 +395,8 @@ class TestStandaloneViewPermissions(WebTest):
             reverse(API_GAME_OFFICIALS, kwargs={"pk": gameinfo.pk}),
             [{"name": "Saskia", "position": "referee"}],
             headers=DBSetup().get_token_header(user=other_user),
-            expect_errors=True,
         )
-        assert response.status_code == 403
+        assert response.status_code == 200
 
     def test_author_can_update_game_officials_for_own_gameday(self):
         gameday = DBSetup().g62_status_empty()


### PR DESCRIPTION
## Summary
- `PR #1596` (closing #1591) generalized a fix for two unauthenticated gameday-designer endpoints (`publish`, `designer_state`) into a blanket staff-or-owner requirement across every mutating gamedays API view — including `GameOfficialCreateOrUpdateView`, which #1591 never named and has no relation to the gameday-designer tool.
- Officials are assigned on-site by whichever team/crew is running the Scorecard for that specific game, not necessarily the gameday's staff or author. There's no staff-gated HTML view for this endpoint the way there is for the gameday-designer views the original PR was actually motivated by.
- That gap silently 403'd every officials submission during the Final 8 / Final 4 tournament (#1634): 13 games across two gamedays finished with zero officials on record, while the sibling `game/<pk>/setup` endpoint — hit by the same "Spiel starten" button, still `IsAuthenticatedOrReadOnly` — let the game start anyway, so nobody noticed until results were reviewed after the fact.
- Reverts `GameOfficialCreateOrUpdateView` to the bare default permission (still blocks anonymous requests, just drops the staff/owner requirement), matching its sibling setup endpoint. Every other endpoint PR #1596 touched is untouched — confirmed via prod log spot-check that all of them are exclusively called from the staff-only `gameday_designer` app and never hit this failure mode.

Closes #1634

## Test plan
- [x] `gamedays/tests/api/test_views.py::TestStandaloneViewPermissions::test_non_staff_non_author_can_update_game_officials` — new/flipped test, confirmed red against the pre-fix code (403), green after
- [x] Full `gamedays/tests/api/` suite: 87 passed, 1 pre-existing unrelated xfail, run against `servyy-test.lxd`
- [x] Verified no regression on the other permission tests PR #1596 added (publish, designer_state, gameinfo, auto-assign-officials, etc. all still correctly staff/owner-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)