### PR TITLE
fix(e2e): stop collapsing the already-open metadata accordion

### DIFF
--- a/gameday_designer/tests/e2e/test_team_selection_generation.py
+++ b/gameday_designer/tests/e2e/test_team_selection_generation.py
@@ -55,8 +55,15 @@ def test_select_existing_teams_during_generation(live_server, page: Page):
     
     # 4. Fill Metadata (to ensure league/season matches)
     expect(page.get_by_test_id("gameday-metadata-accordion")).to_be_visible(timeout=15000)
-    page.get_by_test_id("gameday-metadata-toggle").click()
-    
+
+    # Open the metadata accordion only if it is currently collapsed. It is
+    # expanded by default, so an unconditional click here would collapse it
+    # and race the Bootstrap collapse animation against the fields below.
+    toggle = page.get_by_test_id("gameday-metadata-toggle")
+    if 'collapsed' in (toggle.get_attribute('class') or ''):
+        toggle.click()
+        expect(toggle).not_to_have_class(re.compile(r'collapsed'), timeout=5000)
+
     page.fill("#gamedayName", "Team Selection Test")
     
     # Wait for the season option "2026" to appear (async fetch inside accordion)
@@ -190,7 +197,15 @@ def test_add_team_to_pool_via_team_picker_dialog(live_server, page: Page):
 
     # Set league and season
     expect(page.get_by_test_id("gameday-metadata-accordion")).to_be_visible(timeout=15000)
-    page.get_by_test_id("gameday-metadata-toggle").click()
+
+    # Open the metadata accordion only if it is currently collapsed. It is
+    # expanded by default, so an unconditional click here would collapse it
+    # and race the Bootstrap collapse animation against the fields below.
+    toggle = page.get_by_test_id("gameday-metadata-toggle")
+    if 'collapsed' in (toggle.get_attribute('class') or ''):
+        toggle.click()
+        expect(toggle).not_to_have_class(re.compile(r'collapsed'), timeout=5000)
+
     page.fill("#gamedayName", "Team Pool Test")
     expect(page.locator("#gamedaySeason option", has_text="2026")).to_be_attached(timeout=10000)
     page.select_option("#gamedaySeason", label="2026")


### PR DESCRIPTION
## Summary
- CircleCI job for the webpack 5.109.0 renovate PR ([job 53608](https://app.circleci.com/pipelines/github/dachrisch/leaguesphere/4221/workflows/81bc5069-b1cc-4899-8f3c-b5eb970c6439/jobs/53608)) failed on `test_select_existing_teams_during_generation`, timing out on `page.select_option("#gamedayLeague", ...)` with "element is not visible".
- Traced this across many unrelated CI runs (react, react-dom, web-vitals bumps) over the last few days — same test, same locator, sometimes passing/failing on the identical commit. Not caused by the webpack bump; it's a pre-existing flake.
- Root cause: `GamedayMetadataAccordion` is expanded by default (confirmed by its own unit test: "renders accordion open by default — no click needed"). Both `test_select_existing_teams_during_generation` and `test_add_team_to_pool_via_team_picker_dialog` unconditionally click `gameday-metadata-toggle` right after page load, which actually **collapses** the already-open accordion. The Bootstrap collapse animation then races the following `page.fill`/`select_option` calls — sometimes they land before the fields finish collapsing (pass), sometimes after (timeout).
- Fix: only click the toggle if it is currently collapsed, matching the guard pattern already used later in the same file (`test_template_save_regenerate.py`).

## Test plan
- [ ] CircleCI `e2e` job passes for `gameday_designer` on this branch
- [ ] Re-run CI a few times to confirm `test_select_existing_teams_during_generation` and `test_add_team_to_pool_via_team_picker_dialog` no longer flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)