### PR TITLE
Silence factory_boy postgeneration save deprecation warning

### DIFF
--- a/gamedays/tests/setup_factories/factories.py
+++ b/gamedays/tests/setup_factories/factories.py
@@ -55,6 +55,7 @@ class TeamFactory(DjangoModelFactory):
 class SeasonLeagueTeamFactory(DjangoModelFactory):
     class Meta:
         model = SeasonLeagueTeam
+        skip_postgeneration_save = True
 
     season = factory.SubFactory(SeasonFactory)
     league = factory.SubFactory(LeagueFactory)


### PR DESCRIPTION
## Summary
- `SeasonLeagueTeamFactory`'s `teams` post-generation hook only calls `.add()` on the m2m relation, so the extra instance save factory_boy performs afterward is unnecessary and triggers a deprecation warning in CI (seen in `test_team_selection_generation.py` e2e runs).
- Set `skip_postgeneration_save = True` on the factory's `Meta` to opt into the new behavior.

## Test plan
- [x] CI e2e suite (was producing the warning) should run clean