### PR TITLE
fix(ci): constrain active game check to today's gamedays only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,10 +645,13 @@ jobs:
               exit 0
             fi
 
-            # Check for active games (status indicates in-progress; excludes finished and planned)
-            # "Geplant" games are checked separately in the upcoming 4-hour window below.
+            # Check for active games (status indicates in-progress on today's gamedays).
+            # Past gamedays with stale statuses (e.g. a game stuck in "2. Halbzeit")
+            # should not block deploys. "Geplant" games checked separately below.
+            today_date=$(TZ=Europe/Berlin date +%Y-%m-%d)
             active_count=$(echo "$response" | jq \
-              '[.results[].games[] | select(.status != "beendet" and .status != "Geplant")] | length')
+              --arg today "$today_date" \
+              '[.results[] | select(.date == $today) | .games[] | select(.status != "beendet" and .status != "Geplant")] | length')
             if [ "$active_count" -gt 0 ]; then
               echo "Active games detected ($active_count) - leaving hold_production for manual approval"
               exit 0


### PR DESCRIPTION
## Issue
The active game check was blocking production deploys due to stale game statuses from past gamedays. A game from July 25 stuck in `"2. Halbzeit"` (never marked finished) blocked a Monday deployment.

## Fix
Constrain the active check to **today's gamedays only** by filtering on `date == today` (in Berlin timezone). Past gamedays with stale in-progress statuses are now skipped.

The 4-hour upcoming check already handles this correctly — past games have scheduled times in the past and won't match the `[now, now+4h]` window.

## Edge cases covered
- **Today, game in "2. Halbzeit"** → active check catches it ✅
- **Yesterday, game stuck in "2. Halbzeit"** → active check skips it ✅
- **Today, "Geplant" game starting in 3h** → 4-hour check catches it ✅
- **Next week, "Geplant" games** → 4-hour check skips (>4h away) ✅