### PR TITLE
fix: auto-assign officials against real field count, not stale format

### DIFF
--- a/gamedays/service/auto_assign_officials_service.py
+++ b/gamedays/service/auto_assign_officials_service.py
@@ -55,6 +55,15 @@ class AutoAssignOfficialsService:
                     if gr.team_id:
                         busy_teams.add(gr.team_id)
 
+            # How many distinct *real* fields are in play at this exact
+            # timeslot. If it's just one, games sharing this timeslot can't
+            # truly be concurrent (a field only hosts one game at a time),
+            # so a team playing in another game here is safe to referee.
+            # Scoped per-timeslot (not gameday-wide) so an unrelated later
+            # game on a second field doesn't block an earlier single-field
+            # slot.
+            num_fields_at_time = len({gi.field for gi in games_at_time})
+
             groups: dict[str, list[Gameinfo]] = defaultdict(list)
             for gi in games_at_time:
                 groups[gi.standing].append(gi)
@@ -75,7 +84,27 @@ class AutoAssignOfficialsService:
                     for t in donor_pool
                     if t not in busy_teams and t not in slot_assigned
                 ]
+
                 if not eligible:
+                    if num_fields_at_time > 1:
+                        continue
+                    for gi in gis:
+                        game_busy = {
+                            gr.team_id
+                            for gr in gi.gameresult_set.all()
+                            if gr.team_id
+                        }
+                        per_game_eligible = [
+                            t for t in donor_pool if t not in game_busy
+                        ]
+                        if not per_game_eligible:
+                            continue
+                        per_game_eligible.sort(key=lambda t: referee_count[t])
+                        chosen = per_game_eligible.pop(0)
+                        gi.officials_id = chosen
+                        gi.save(update_fields=["officials"])
+                        referee_count[chosen] += 1
+                        assignments[gi.pk] = chosen
                     continue
 
                 for gi in gis:
@@ -106,7 +135,8 @@ class AutoAssignOfficialsService:
             return {}
 
         state_data = state.state_data or {}
-        game_nodes = [n for n in state_data.get("nodes", []) if n.get("type") == "game"]
+        nodes = state_data.get("nodes", [])
+        game_nodes = [n for n in nodes if n.get("type") == "game"]
         if not game_nodes:
             return {}
 
@@ -114,7 +144,13 @@ class AutoAssignOfficialsService:
             t["id"] for t in state_data.get("globalTeams", []) if t.get("id")
         }
 
-        num_fields = self._get_num_fields()
+        # Prefer the number of field nodes actually present on the current
+        # canvas over the gameday's template format string, which goes
+        # stale as soon as a user adds/removes a field in the designer
+        # without recreating the gameday (e.g. a "6_2" template reduced to
+        # a single field still reports 2 fields via format alone).
+        field_node_count = sum(1 for n in nodes if n.get("type") == "field")
+        num_fields = field_node_count if field_node_count else self._get_num_fields()
 
         all_teams_in_standing: dict[str, set[str]] = defaultdict(set)
         for node in game_nodes:

--- a/gamedays/tests/service/test_auto_assign_officials.py
+++ b/gamedays/tests/service/test_auto_assign_officials.py
@@ -222,6 +222,142 @@ class TestAutoAssignOfficialsService(TestCase):
 
         assert a1 == a2, "Assignments differ between runs"
 
+    def test_single_real_field_same_time_same_standing_still_assigns(self):
+        """Regression: unlike the designer-state path, _assign_from_gameinfos
+        had no single-field fallback at all. 4 teams, 2 games both on the
+        same real field (field=1) at the same scheduled time and standing --
+        the whole team pool is exhausted, but since it's one physical field
+        the games are actually sequential, so referees should still be
+        assignable. The gameday's stale format ("6_2") must not matter --
+        only the real `field` values on the Gameinfo rows do."""
+        gameday = Gameday.objects.create(
+            name="4 Teams 1 Real Field",
+            season=Season.objects.create(name="2026"),
+            league=League.objects.create(name="Test"),
+            date="2026-07-16",
+            start="10:00",
+            author=self.user,
+            status="DRAFT",
+            format="6_2",
+        )
+        teams = [
+            Team.objects.create(name=f"Team {i}", description=f"T{i}") for i in range(4)
+        ]
+        for home, away in [(teams[0], teams[1]), (teams[2], teams[3])]:
+            gi = Gameinfo.objects.create(
+                gameday=gameday,
+                scheduled="10:00",
+                field=1,
+                stage="Vorrunde",
+                standing="Gruppe 1",
+                status="Geplant",
+                officials=home,
+            )
+            Gameresult.objects.create(gameinfo=gi, team=home, isHome=True)
+            Gameresult.objects.create(gameinfo=gi, team=away, isHome=False)
+
+        service = AutoAssignOfficialsService(gameday.pk)
+        assignments = service.assign()
+
+        assert (
+            len(assignments) == 2
+        ), f"Expected 2 assignments, got {len(assignments)}: {assignments}"
+        self._assert_no_self_referee(gameday)
+
+    def test_two_real_fields_same_time_same_standing_skips_when_impossible(self):
+        """Opposite direction of the above: 2 games on 2 DIFFERENT real
+        fields at the exact same scheduled time -- truly concurrent, so no
+        team is free to referee either game. Must not cross-assign a team
+        that is simultaneously playing on the other field."""
+        gameday = Gameday.objects.create(
+            name="4 Teams 2 Real Fields",
+            season=Season.objects.create(name="2026"),
+            league=League.objects.create(name="Test"),
+            date="2026-07-16",
+            start="10:00",
+            author=self.user,
+            status="DRAFT",
+            format="4_1",
+        )
+        teams = [
+            Team.objects.create(name=f"Team {i}", description=f"T{i}") for i in range(4)
+        ]
+        for field, home, away in [(1, teams[0], teams[1]), (2, teams[2], teams[3])]:
+            gi = Gameinfo.objects.create(
+                gameday=gameday,
+                scheduled="10:00",
+                field=field,
+                stage="Vorrunde",
+                standing="Gruppe 1",
+                status="Geplant",
+                officials=home,
+            )
+            Gameresult.objects.create(gameinfo=gi, team=home, isHome=True)
+            Gameresult.objects.create(gameinfo=gi, team=away, isHome=False)
+
+        service = AutoAssignOfficialsService(gameday.pk)
+        assignments = service.assign()
+
+        assert assignments == {}, (
+            f"Expected 0 assignments (2 concurrent real fields), "
+            f"got {len(assignments)}: {assignments}"
+        )
+
+    def test_field_count_evaluated_per_timeslot_not_gameday_wide(self):
+        """A gameday can legitimately use 2 different fields at different
+        times (e.g. round-robin overflow). The single-field fallback must
+        be gated on how many real fields are in play AT THAT TIMESLOT, not
+        on how many fields the gameday uses anywhere -- otherwise an
+        unrelated later game on field 2 would wrongly block assignment for
+        an earlier, single-field time slot."""
+        gameday = Gameday.objects.create(
+            name="Mixed Field Usage",
+            season=Season.objects.create(name="2026"),
+            league=League.objects.create(name="Test"),
+            date="2026-07-16",
+            start="10:00",
+            author=self.user,
+            status="DRAFT",
+            format="4_1",
+        )
+        teams = [
+            Team.objects.create(name=f"Team {i}", description=f"T{i}") for i in range(4)
+        ]
+        # 10:00 -- both games on field 1 (single real field at this time).
+        for home, away in [(teams[0], teams[1]), (teams[2], teams[3])]:
+            gi = Gameinfo.objects.create(
+                gameday=gameday,
+                scheduled="10:00",
+                field=1,
+                stage="Vorrunde",
+                standing="Gruppe 1",
+                status="Geplant",
+                officials=home,
+            )
+            Gameresult.objects.create(gameinfo=gi, team=home, isHome=True)
+            Gameresult.objects.create(gameinfo=gi, team=away, isHome=False)
+        # 11:10 -- unrelated later game on field 2. Makes the gameday touch
+        # 2 distinct fields overall, but not at the 10:00 timeslot.
+        gi = Gameinfo.objects.create(
+            gameday=gameday,
+            scheduled="11:10",
+            field=2,
+            stage="Vorrunde",
+            standing="Gruppe 1",
+            status="Geplant",
+            officials=teams[0],
+        )
+        Gameresult.objects.create(gameinfo=gi, team=teams[0], isHome=True)
+        Gameresult.objects.create(gameinfo=gi, team=teams[2], isHome=False)
+
+        service = AutoAssignOfficialsService(gameday.pk)
+        assignments = service.assign()
+
+        assert (
+            len(assignments) == 3
+        ), f"Expected all 3 games assigned, got {len(assignments)}: {assignments}"
+        self._assert_no_self_referee(gameday)
+
 
 class TestAutoAssignOfficialsServiceDesignerState(TestCase):
     """
@@ -282,6 +418,9 @@ class TestAutoAssignOfficialsServiceDesignerState(TestCase):
             "parentId": parent_id,
             "data": data,
         }
+
+    def _field_node(self, node_id):
+        return {"id": node_id, "type": "field", "data": {}}
 
     def test_idle_team_in_pool_is_assigned_as_referee(self):
         """Reproduces the reported bug: 3 registered teams, 1 game between
@@ -453,3 +592,85 @@ class TestAutoAssignOfficialsServiceDesignerState(TestCase):
         assert assignments["game-1"] in {"team-c", "team-d"}
         # Game 2 has an explicit later time, so Game 1's teams are free too
         assert assignments["game-2"] in {"team-a", "team-b"}
+
+    def test_stale_format_claiming_two_fields_does_not_block_single_real_field(self):
+        """Reproduces the reported bug (gameday 897 on stage): the gameday
+        was created from a 2-field template (format="6_2") but the user has
+        since reduced the designer canvas down to a single field node. 4
+        registered teams, 2 games in the same standing/stage exhaust the
+        whole pool -- the stale format string must not stop the
+        single-field fallback from finding referees for a canvas that
+        currently only has 1 real field."""
+        gameday = Gameday.objects.create(
+            name="Stale Two-Field Format",
+            season=self.season,
+            league=self.league,
+            date="2026-07-16",
+            start="10:00",
+            author=self.user,
+            status="DRAFT",
+            format="6_2",
+        )
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    self._field_node("field-1"),
+                    self._game_node("game-1", "Game 1", "team-a", "team-b"),
+                    self._game_node("game-2", "Game 1", "team-c", "team-d"),
+                ],
+                "globalTeams": [
+                    {"id": t, "label": t, "groupId": "group-1", "order": 0}
+                    for t in ("team-a", "team-b", "team-c", "team-d")
+                ],
+                "globalTeamGroups": [{"id": "group-1", "name": "Group 1", "order": 0}],
+            },
+        )
+
+        service = AutoAssignOfficialsService(gameday.pk)
+        assignments = service.assign()
+
+        assert (
+            len(assignments) == 2
+        ), f"Expected 2 assignments, got {len(assignments)}: {assignments}"
+        assert set(assignments.values()) <= {"team-a", "team-b", "team-c", "team-d"}
+
+    def test_two_real_field_nodes_override_misleading_single_field_format(self):
+        """Opposite direction: format says "4_1" (1 field) but the designer
+        canvas actually has 2 field nodes. Must not unsafely widen
+        assignment to a team that could be concurrently busy on the other
+        real field just because the stale format claims there's only one."""
+        gameday = Gameday.objects.create(
+            name="Misleading Single-Field Format",
+            season=self.season,
+            league=self.league,
+            date="2026-07-16",
+            start="10:00",
+            author=self.user,
+            status="DRAFT",
+            format="4_1",
+        )
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    self._field_node("field-1"),
+                    self._field_node("field-2"),
+                    self._game_node("game-1", "Game 1", "team-a", "team-b"),
+                    self._game_node("game-2", "Game 1", "team-c", "team-d"),
+                ],
+                "globalTeams": [
+                    {"id": t, "label": t, "groupId": "group-1", "order": 0}
+                    for t in ("team-a", "team-b", "team-c", "team-d")
+                ],
+                "globalTeamGroups": [{"id": "group-1", "name": "Group 1", "order": 0}],
+            },
+        )
+
+        service = AutoAssignOfficialsService(gameday.pk)
+        assignments = service.assign()
+
+        assert assignments == {}, (
+            f"Expected 0 assignments (2 real field nodes => can't assume "
+            f"sequential), got {len(assignments)}: {assignments}"
+        )


### PR DESCRIPTION
## Summary
- `AutoAssignOfficialsService` derived field count from the gameday's template `format` string (e.g. `"6_2"`) instead of the designer's actual current state. Reducing a multi-field template to a single field in the designer left the format string stale, so the single-field fallback added by #1662 never triggered — 0 referee assignments. Reproduced live on stage (gameday 897).
- Designer-state path now counts real `type=="field"` canvas nodes, falling back to the format string only when none exist.
- Gameinfos path (published-then-reverted-to-draft gamedays) had no single-field fallback at all — same class of bug, previously uncovered. Ported the fallback using each Gameinfo's real `field` number, scoped per timeslot.

## Test plan
- [x] TDD: 5 new tests written first and confirmed red against the old code
- [x] `pytest gamedays/tests/service/test_auto_assign_officials.py` — 21 passed
- [x] `pytest gamedays/` (full suite, `-n auto`) — 378 passed, 1 xfailed, no regressions
- [x] Reproduced original bug live on stage.leaguesphere.app (gameday 897) via Chrome MCP before fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)