### PR TITLE
fix(gamedays): stop leaking exception detail from auto-assign officials endpoint

### DIFF
--- a/gamedays/api/views.py
+++ b/gamedays/api/views.py
@@ -1,5 +1,6 @@
 import json
 import hashlib
+import logging
 from collections import OrderedDict
 from datetime import datetime
 
@@ -59,6 +60,8 @@ from gamedays.service.gameday_settings import (
     STANDING,
     WIN_POINTS,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _check_gameday_mutation_permission(request, gameday) -> bool:
@@ -531,7 +534,11 @@ class AutoAssignOfficialsView(APIView):
                 {"assigned_count": len(assignments), "assignments": assignments}
             )
         except AutoAssignOfficialsError as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            logger.warning("Auto-assign officials failed for gameday %s: %s", pk, e)
+            return Response(
+                {"error": "Unable to auto-assign officials for this gameday."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
 
 class GameResultsUpdateView(APIView):

--- a/gamedays/tests/api/test_views.py
+++ b/gamedays/tests/api/test_views.py
@@ -12,6 +12,7 @@ from rest_framework.reverse import reverse
 from gamedays.api.serializers import GamedaySerializer, GameinfoSerializer
 from gamedays.constants import API_GAMEDAY_WHISTLEGAMES, API_GAMEDAY_LIST, API_GAME_OFFICIALS
 from gamedays.models import Team, Gameday, Gameinfo
+from gamedays.service.auto_assign_officials_service import AutoAssignOfficialsError
 from gamedays.service.gameday_service import EmptySchedule, EmptyQualifyTable
 from gamedays.tests.setup_factories.db_setup import DBSetup
 from league_table.tests.setup_factories.db_setup_leaguetable import LEAGUE_TABLE_TEST_RULESET
@@ -366,6 +367,28 @@ class TestStandaloneViewPermissions(WebTest):
         # The response may be 200 (success) or 400 (no designer state / validation error)
         # depending on the gameday setup — the point is it is NOT 401/403.
         assert response.status_code in (200, 400)
+
+    def test_auto_assign_officials_error_does_not_leak_exception_detail(self):
+        """CodeQL py/stack-trace-exposure (alert #69): the raw exception text
+        must never reach the HTTP response, only the server-side log."""
+        author, gameday = self._create_gameday_with_author("aa_author5")
+        staff_user = DBSetup().create_new_user("aa_staff3", is_staff=True)
+        sensitive_detail = "internal detail: /srv/leaguesphere/secret_config.py line 42"
+
+        with patch(
+            "gamedays.api.views.AutoAssignOfficialsService.assign",
+            side_effect=AutoAssignOfficialsError(sensitive_detail),
+        ):
+            with self.assertLogs("gamedays.api.views", level="WARNING") as logs:
+                response = self.app.post(
+                    reverse("api-gameday-auto-assign-officials", kwargs={"pk": gameday.pk}),
+                    headers=DBSetup().get_token_header(user=staff_user),
+                    expect_errors=True,
+                )
+
+        assert response.status_code == 400
+        assert sensitive_detail not in response.text
+        assert any(sensitive_detail in message for message in logs.output)
 
     # ── GameOfficialCreateOrUpdateView (PUT /api/game/{id}/officials) ──
 


### PR DESCRIPTION
## Summary
- Fixes [code-scanning alert #69](https://github.com/dachrisch/leaguesphere/security/code-scanning/69) (`py/stack-trace-exposure`, CWE-209/497)
- `AutoAssignOfficialsView.post` returned `str(e)` from a caught `AutoAssignOfficialsError` directly in the API response body — CodeQL flags any exception content reaching an external user as a potential info-exposure risk, since a future change could accidentally wrap sensitive detail (e.g. a lower-level exception/traceback) into that error
- The exception is now logged server-side (`logger.warning`) and the client receives a fixed, generic message instead of exception-derived text, breaking the tainted data flow
- Confirmed the frontend never consumed the specific error text (it shows a static i18n notification regardless), so there's no UX regression

## Test plan
- [x] Added `test_auto_assign_officials_error_does_not_leak_exception_detail`, which mocks the service to raise with a sentinel string and asserts it never appears in the response body but is present in the server log; verified it fails on the pre-fix code and passes after
- [x] `pytest gamedays/tests/api/test_views.py gamedays/tests/service/test_auto_assign_officials.py` — 51 passed, 1 pre-existing unrelated xfail
- [x] `black --check` diffs on the touched files are pre-existing on master (local black targets py3.15, env runs py3.14) — confirmed via `git stash` this isn't introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)