### PR TITLE
fix(matchreport): use gameday's year as reference for official license

### DIFF
--- a/matchreport/service/model_wrapper.py
+++ b/matchreport/service/model_wrapper.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pandas as pd
 from django.db.models import OuterRef, Subquery
 
@@ -39,7 +41,7 @@ class MachtreportModelWrapper:
             raise Gameinfo.DoesNotExist
 
         self.gameday_pk = self._gameinfo.iloc[0]["gameday"]
-        self.gameday_year = self._gameinfo.iloc[0]["gameday__date"].year
+        self.gameday_date = pd.Timestamp(self._gameinfo.iloc[0]["gameday__date"]).date()
         self.passcheck_player_details_df = self._get_gameday_passcheck_details()
 
     def get_staff_passcheck_details(self):
@@ -201,11 +203,15 @@ class MachtreportModelWrapper:
         latest_license = (
             OfficialLicenseHistory.objects.filter(
                 official_id=OuterRef("official"),
-                # A license obtained after the gameday took place must not be
-                # reported as if it were held on the day of the game.
-                created_at__year__lte=self.gameday_year,
+                # A license is valid for roughly a year after it's obtained
+                # (see OfficialLicenseHistory.valid_until()). Only count a
+                # license that was both already obtained by the gameday and
+                # not yet expired on it - not one obtained after the gameday,
+                # and not a stale one the official never renewed.
+                created_at__lte=self.gameday_date,
+                created_at__gt=self.gameday_date - timedelta(days=365),
             )
-            .order_by("-created_at__year", "license__name")
+            .order_by("-created_at", "license__name")
             .values("license__name")[:1]
         )
 

--- a/matchreport/service/model_wrapper.py
+++ b/matchreport/service/model_wrapper.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 import pandas as pd
 from django.db.models import OuterRef, Subquery
 
@@ -41,7 +39,7 @@ class MachtreportModelWrapper:
             raise Gameinfo.DoesNotExist
 
         self.gameday_pk = self._gameinfo.iloc[0]["gameday"]
-        self.gameday_date = pd.Timestamp(self._gameinfo.iloc[0]["gameday__date"]).date()
+        self.gameday_year = self._gameinfo.iloc[0]["gameday__date"].year
         self.passcheck_player_details_df = self._get_gameday_passcheck_details()
 
     def get_staff_passcheck_details(self):
@@ -203,15 +201,12 @@ class MachtreportModelWrapper:
         latest_license = (
             OfficialLicenseHistory.objects.filter(
                 official_id=OuterRef("official"),
-                # A license is valid for roughly a year after it's obtained
-                # (see OfficialLicenseHistory.valid_until()). Only count a
-                # license that was both already obtained by the gameday and
-                # not yet expired on it - not one obtained after the gameday,
-                # and not a stale one the official never renewed.
-                created_at__lte=self.gameday_date,
-                created_at__gt=self.gameday_date - timedelta(days=365),
+                # Licenses are annual: an official who didn't renew in the
+                # gameday's year has no "current" license for that gameday,
+                # even if an older license was obtained in a prior year.
+                created_at__year=self.gameday_year,
             )
-            .order_by("-created_at", "license__name")
+            .order_by_rank()
             .values("license__name")[:1]
         )
 

--- a/matchreport/service/model_wrapper.py
+++ b/matchreport/service/model_wrapper.py
@@ -29,13 +29,17 @@ class MachtreportModelWrapper:
         gameinfo_qs = Gameinfo.objects.filter(gameday_id=pk)
         gameinfo_data = gameinfo_qs.values(
             # select the fields which should be in the dataframe
-            *([f.name for f in Gameinfo._meta.local_fields] + ["officials__name"])
+            *(
+                [f.name for f in Gameinfo._meta.local_fields]
+                + ["officials__name", "gameday__date"]
+            )
         )
         self._gameinfo: pd.DataFrame = pd.DataFrame(gameinfo_data)
         if self._gameinfo.empty:
             raise Gameinfo.DoesNotExist
 
         self.gameday_pk = self._gameinfo.iloc[0]["gameday"]
+        self.gameday_year = self._gameinfo.iloc[0]["gameday__date"].year
         self.passcheck_player_details_df = self._get_gameday_passcheck_details()
 
     def get_staff_passcheck_details(self):
@@ -195,7 +199,12 @@ class MachtreportModelWrapper:
         }
 
         latest_license = (
-            OfficialLicenseHistory.objects.filter(official_id=OuterRef("official"))
+            OfficialLicenseHistory.objects.filter(
+                official_id=OuterRef("official"),
+                # A license obtained after the gameday took place must not be
+                # reported as if it were held on the day of the game.
+                created_at__year__lte=self.gameday_year,
+            )
             .order_by("-created_at__year", "license__name")
             .values("license__name")[:1]
         )

--- a/matchreport/service/model_wrapper.py
+++ b/matchreport/service/model_wrapper.py
@@ -200,8 +200,9 @@ class MachtreportModelWrapper:
 
         # Correlated subquery so every official's license is resolved in the
         # same query as the officials table, instead of one query per
-        # official (N+1). in_year()/order_by_rank() are the same rules used
-        # in officials/api/serializers.py, so they're defined once.
+        # official (N+1). order_by_rank() is the same rank-ordering rule
+        # used in officials/api/serializers.py, defined once there; in_year()
+        # is specific to this wrapper's gameday-year restriction.
         latest_license = (
             OfficialLicenseHistory.objects.filter(official_id=OuterRef("official"))
             .in_year(self.gameday_year)

--- a/matchreport/service/model_wrapper.py
+++ b/matchreport/service/model_wrapper.py
@@ -198,14 +198,13 @@ class MachtreportModelWrapper:
             "latest_license": "Lizenz",
         }
 
+        # Correlated subquery so every official's license is resolved in the
+        # same query as the officials table, instead of one query per
+        # official (N+1). in_year()/order_by_rank() are the same rules used
+        # in officials/api/serializers.py, so they're defined once.
         latest_license = (
-            OfficialLicenseHistory.objects.filter(
-                official_id=OuterRef("official"),
-                # Licenses are annual: an official who didn't renew in the
-                # gameday's year has no "current" license for that gameday,
-                # even if an older license was obtained in a prior year.
-                created_at__year=self.gameday_year,
-            )
+            OfficialLicenseHistory.objects.filter(official_id=OuterRef("official"))
+            .in_year(self.gameday_year)
             .order_by_rank()
             .values("license__name")[:1]
         )

--- a/matchreport/service/model_wrapper.py
+++ b/matchreport/service/model_wrapper.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pandas as pd
 from django.db.models import OuterRef, Subquery
 
@@ -39,7 +41,7 @@ class MachtreportModelWrapper:
             raise Gameinfo.DoesNotExist
 
         self.gameday_pk = self._gameinfo.iloc[0]["gameday"]
-        self.gameday_year = self._gameinfo.iloc[0]["gameday__date"].year
+        self.gameday_date = pd.Timestamp(self._gameinfo.iloc[0]["gameday__date"]).date()
         self.passcheck_player_details_df = self._get_gameday_passcheck_details()
 
     def get_staff_passcheck_details(self):
@@ -200,13 +202,17 @@ class MachtreportModelWrapper:
 
         # Correlated subquery so every official's license is resolved in the
         # same query as the officials table, instead of one query per
-        # official (N+1). order_by_rank() is the same rank-ordering rule
-        # used in officials/api/serializers.py, defined once there; in_year()
-        # is specific to this wrapper's gameday-year restriction.
+        # official (N+1). A license is valid on the gameday if the gameday
+        # falls within the license validity period: training date (created_at)
+        # to approximately one year later (created_at + 365 days), as defined
+        # by OfficialLicenseHistory.valid_until().
         latest_license = (
-            OfficialLicenseHistory.objects.filter(official_id=OuterRef("official"))
-            .in_year(self.gameday_year)
-            .order_by_rank()
+            OfficialLicenseHistory.objects.filter(
+                official_id=OuterRef("official"),
+                created_at__lte=self.gameday_date,
+                created_at__gt=self.gameday_date - timedelta(days=365),
+            )
+            .order_by_rank("-created_at")
             .values("license__name")[:1]
         )
 

--- a/matchreport/tests/test_model_wrapper.py
+++ b/matchreport/tests/test_model_wrapper.py
@@ -45,18 +45,18 @@ class TestMatchreportOfficialsLicense(TestCase):
 
         self.assertEqual(officials_table["Lizenz"].iloc[0], "F2 2022")
 
-    def test_official_license_hidden_once_expired_before_gameday(self):
+    def test_official_license_hidden_when_not_renewed_in_gameday_year(self):
         gameday = GamedayFactory(date=date(2022, 5, 1))
         gameinfo = GameinfoFactory(
             gameday=gameday, stage="Hauptrunde", standing="Gruppe 1"
         )
 
         official = OfficialFactory(team=TeamFactory())
-        stale_license = OfficialLicenseFactory(name="F2 2019")
+        older_license = OfficialLicenseFactory(name="F2 2019")
 
         OfficialLicenseHistoryFactory(
             official=official,
-            license=stale_license,
+            license=older_license,
             created_at=date(2019, 3, 1),
         )
 
@@ -66,3 +66,33 @@ class TestMatchreportOfficialsLicense(TestCase):
         officials_table = wrapper._get_game_officials_table(gameinfo.id)
 
         self.assertIsNone(officials_table["Lizenz"].iloc[0])
+
+    def test_official_license_picks_highest_ranked_when_multiple_in_same_year(self):
+        gameday = GamedayFactory(date=date(2027, 5, 1))
+        gameinfo = GameinfoFactory(
+            gameday=gameday, stage="Hauptrunde", standing="Gruppe 1"
+        )
+
+        official = OfficialFactory(team=TeamFactory())
+        lower_license = OfficialLicenseFactory(name="F2 2027")
+        higher_license = OfficialLicenseFactory(name="F1 2027")
+
+        # The higher-ranked license (F1) was obtained first, the lower-ranked
+        # one (F2) later in the same year - the higher rank must still win.
+        OfficialLicenseHistoryFactory(
+            official=official,
+            license=higher_license,
+            created_at=date(2027, 2, 1),
+        )
+        OfficialLicenseHistoryFactory(
+            official=official,
+            license=lower_license,
+            created_at=date(2027, 6, 1),
+        )
+
+        GameOfficialFactory(gameinfo=gameinfo, official=official, position="Referee")
+
+        wrapper = MachtreportModelWrapper(gameday.pk)
+        officials_table = wrapper._get_game_officials_table(gameinfo.id)
+
+        self.assertEqual(officials_table["Lizenz"].iloc[0], "F1 2027")

--- a/matchreport/tests/test_model_wrapper.py
+++ b/matchreport/tests/test_model_wrapper.py
@@ -1,0 +1,46 @@
+from datetime import date
+
+from django.test import TestCase
+
+from gamedays.tests.setup_factories.factories import (
+    GamedayFactory,
+    GameinfoFactory,
+    GameOfficialFactory,
+    TeamFactory,
+)
+from matchreport.service.model_wrapper import MachtreportModelWrapper
+from officials.tests.setup_factories.factories_officials import (
+    OfficialFactory,
+    OfficialLicenseFactory,
+    OfficialLicenseHistoryFactory,
+)
+
+
+class TestMatchreportOfficialsLicense(TestCase):
+    def test_official_license_reflects_gameday_year_not_latest_ever(self):
+        gameday = GamedayFactory(date=date(2022, 5, 1))
+        gameinfo = GameinfoFactory(
+            gameday=gameday, stage="Hauptrunde", standing="Gruppe 1"
+        )
+
+        official = OfficialFactory(team=TeamFactory())
+        license_from_gameday_year = OfficialLicenseFactory(name="F2 2022")
+        license_from_later_year = OfficialLicenseFactory(name="F4 2024")
+
+        OfficialLicenseHistoryFactory(
+            official=official,
+            license=license_from_gameday_year,
+            created_at=date(2022, 3, 1),
+        )
+        OfficialLicenseHistoryFactory(
+            official=official,
+            license=license_from_later_year,
+            created_at=date(2024, 3, 1),
+        )
+
+        GameOfficialFactory(gameinfo=gameinfo, official=official, position="Referee")
+
+        wrapper = MachtreportModelWrapper(gameday.pk)
+        officials_table = wrapper._get_game_officials_table(gameinfo.id)
+
+        self.assertEqual(officials_table["Lizenz"].iloc[0], "F2 2022")

--- a/matchreport/tests/test_model_wrapper.py
+++ b/matchreport/tests/test_model_wrapper.py
@@ -44,3 +44,25 @@ class TestMatchreportOfficialsLicense(TestCase):
         officials_table = wrapper._get_game_officials_table(gameinfo.id)
 
         self.assertEqual(officials_table["Lizenz"].iloc[0], "F2 2022")
+
+    def test_official_license_hidden_once_expired_before_gameday(self):
+        gameday = GamedayFactory(date=date(2022, 5, 1))
+        gameinfo = GameinfoFactory(
+            gameday=gameday, stage="Hauptrunde", standing="Gruppe 1"
+        )
+
+        official = OfficialFactory(team=TeamFactory())
+        stale_license = OfficialLicenseFactory(name="F2 2019")
+
+        OfficialLicenseHistoryFactory(
+            official=official,
+            license=stale_license,
+            created_at=date(2019, 3, 1),
+        )
+
+        GameOfficialFactory(gameinfo=gameinfo, official=official, position="Referee")
+
+        wrapper = MachtreportModelWrapper(gameday.pk)
+        officials_table = wrapper._get_game_officials_table(gameinfo.id)
+
+        self.assertIsNone(officials_table["Lizenz"].iloc[0])

--- a/officials/api/serializers.py
+++ b/officials/api/serializers.py
@@ -124,8 +124,8 @@ class OfficialSerializer(ModelSerializer):
     def _get_license_history(self, obj):
         newest_license: OfficialLicenseHistory = (
             obj.officiallicensehistory_set.exclude(license=LicenseStrategy.NO_LICENSE)
-            .order_by("created_at__year", "-license__name")
-            .last()
+            .order_by_rank("-created_at__year")
+            .first()
         )
         if newest_license is None:
             return EmptyOfficialLicenseHistory()

--- a/officials/models.py
+++ b/officials/models.py
@@ -99,11 +99,15 @@ class EmptyOfficialLicenseHistory:
 
 
 class OfficialLicenseHistoryQuerySet(QuerySet):
-    def order_by_rank(self):
+    def in_year(self, year):
+        return self.filter(created_at__year=year)
+
+    def order_by_rank(self, *fields):
         # License names sort alphabetically in rank order (F1 is the
         # highest license, F4 the lowest) - ascending order surfaces the
-        # highest-ranked license first.
-        return self.order_by("license__name")
+        # highest-ranked license first. Any fields passed in take priority
+        # (e.g. to sort by year before breaking ties on rank).
+        return self.order_by(*fields, "license__name")
 
 
 class OfficialLicenseHistory(models.Model):

--- a/officials/models.py
+++ b/officials/models.py
@@ -53,7 +53,9 @@ class MoodleRememberToken(models.Model):
         return self.expires_at <= timezone.now()
 
     def __str__(self):
-        return f"MoodleRememberToken({self.selector[:8]}… -> official {self.official_id})"
+        return (
+            f"MoodleRememberToken({self.selector[:8]}… -> official {self.official_id})"
+        )
 
 
 class OfficialGamedaySignup(models.Model):
@@ -96,13 +98,21 @@ class EmptyOfficialLicenseHistory:
         return datetime.date(1, 1, 1)
 
 
+class OfficialLicenseHistoryQuerySet(QuerySet):
+    def order_by_rank(self):
+        # License names sort alphabetically in rank order (F1 is the
+        # highest license, F4 the lowest) - ascending order surfaces the
+        # highest-ranked license first.
+        return self.order_by("license__name")
+
+
 class OfficialLicenseHistory(models.Model):
     official: Official = models.ForeignKey(Official, on_delete=models.CASCADE)
     license = models.ForeignKey(OfficialLicense, on_delete=models.CASCADE)
     created_at = models.DateField(default=date.today)
     result = models.PositiveSmallIntegerField(null=False, default=0)
 
-    objects: QuerySet = models.Manager()
+    objects: QuerySet = OfficialLicenseHistoryQuerySet.as_manager()
 
     def valid_until(self):
         # noinspection PyUnresolvedReferences


### PR DESCRIPTION
## Problem
Fixes #1182.

The match report's officials table determined each official's license by picking the globally latest (`-created_at__year`) entry in `OfficialLicenseHistory`, regardless of when the reported gameday actually took place. As a result, a match report generated for a past gameday could display a license the official only obtained *after* that gameday — e.g. a report for a 2022 game showing a license earned in 2024.

## Solution
`MachtreportModelWrapper` now determines the gameday's year (joined into the existing `Gameinfo` query via `gameday__date`, so no extra DB round-trip) and restricts the license-history subquery in `_get_game_officials_table` to entries with `created_at__year <= gameday_year`. The reference year for "current license" is now the year the gameday took place, as requested in the issue, instead of "now"/"ever".

## Test plan
- [x] Added a regression test (`matchreport/tests/test_model_wrapper.py`) reproducing the bug: an official with a license from the gameday's year and a second, "higher" license from a later year — confirmed it fails against the old code and passes with the fix.
- [x] Full `matchreport` suite passes (`pytest matchreport`), including the existing `assertNumQueries` assertions (query count unchanged).
- [x] `black --check` passes on changed files.