### PR TITLE
Fix designer save-as-template num_fields desync

### DIFF
--- a/gameday_designer/src/utils/__tests__/templateMapper.test.ts
+++ b/gameday_designer/src/utils/__tests__/templateMapper.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { genericizeFlowState, applyGenericTemplate } from '../templateMapper';
-import { FlowState, GlobalTeam, GlobalTeamGroup, FlowNode, isGameNode } from '../../types/flowchart';
+import {
+  FlowState,
+  GlobalTeam,
+  GlobalTeamGroup,
+  FlowNode,
+  isGameNode,
+  createFieldNode,
+  createStageNode,
+  createGameNodeInStage,
+} from '../../types/flowchart';
 
 describe('templateMapper', () => {
   it('should correctly genericize teams into group and team indices', () => {
@@ -113,5 +122,41 @@ describe('templateMapper', () => {
     expect(officialTeam?.groupId).toBe(groups[1].id); // g2 = External Officials
     expect(gameNode.data.startTime).toBe('09:30');
     expect(gameNode.data.manualTime).toBe(true);
+  });
+
+  it('derives num_fields and per-slot field index from the field container nodes, not the legacy fields metadata array', () => {
+    // Reproduces production bug: gamedays built via the "Add Field" designer button
+    // (nodesManager.addFieldNode) never populate the separate `fields` metadata array,
+    // so it stays empty even though real field container nodes exist in `nodes`.
+    const groups: GlobalTeamGroup[] = [{ id: 'g1', name: 'Group A', order: 0 }];
+    const teams: GlobalTeam[] = [
+      { id: 't1', label: 'Team 1', groupId: 'g1', order: 0 },
+      { id: 't2', label: 'Team 2', groupId: 'g1', order: 1 },
+      { id: 't3', label: 'Team 3', groupId: 'g1', order: 2 },
+      { id: 't4', label: 'Team 4', groupId: 'g1', order: 3 },
+    ];
+
+    const field1 = createFieldNode('field-1', { name: 'Feld 1', order: 0 });
+    const field2 = createFieldNode('field-2', { name: 'Feld 2', order: 1 });
+    const stage1 = createStageNode('stage-1', field1.id, { name: 'Preliminary', order: 0 });
+    const stage2 = createStageNode('stage-2', field2.id, { name: 'Preliminary', order: 0 });
+    const game1 = createGameNodeInStage('game-1', stage1.id, {
+      standing: 'A1', homeTeamId: 't1', awayTeamId: 't2', official: null, breakAfter: 0,
+    });
+    const game2 = createGameNodeInStage('game-2', stage2.id, {
+      standing: 'B1', homeTeamId: 't3', awayTeamId: 't4', official: null, breakAfter: 0,
+    });
+
+    const nodes: FlowNode[] = [field1, field2, stage1, stage2, game1, game2];
+
+    // `fields` is empty, mirroring the real desynced production data for gameday 895.
+    const flowState = { nodes, edges: [], fields: [], globalTeams: teams, globalTeamGroups: groups } as unknown as FlowState;
+
+    const template = genericizeFlowState(flowState, 'Multi-Field Test');
+
+    expect(template.num_fields).toBe(2);
+    const fieldByStanding = new Map(template.slots.map(s => [s.standing, s.field]));
+    expect(fieldByStanding.get('A1')).toBe(1);
+    expect(fieldByStanding.get('B1')).toBe(2);
   });
 });

--- a/gameday_designer/src/utils/templateMapper.ts
+++ b/gameday_designer/src/utils/templateMapper.ts
@@ -1,4 +1,4 @@
-import { FlowState, GlobalTeam, FlowNode, isGameNode, isStageNode, createGameNodeInStage, createGameToGameEdge, createStageToGameEdge, FlowEdge, GlobalTeamGroup, StageCategory, StageToGameEdgeData } from '../types/flowchart';
+import { FlowState, GlobalTeam, FlowNode, isGameNode, isStageNode, isFieldNode, createGameNodeInStage, createGameToGameEdge, createStageToGameEdge, FlowEdge, GlobalTeamGroup, StageCategory, StageToGameEdgeData } from '../types/flowchart';
 import { isWinnerReference, isLoserReference, isGroupTeamReference, isRankReference, isGroupRankReference, TeamReference } from '../types/designer';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -121,7 +121,11 @@ export function genericizeFlowState(state: FlowState, name: string, description:
   };
 
   const gameNodes = state.nodes.filter(isGameNode);
-  const fieldsList = [...state.fields].sort((a, b) => a.order - b.order);
+  // Field container nodes are the source of truth for field count/order, not the
+  // separate `fields` metadata array: that array is only kept in sync by the
+  // tournament-generator and import flows, while the "Add Field" designer button
+  // and automatic hierarchy creation only ever push a node onto `state.nodes`.
+  const fieldsList = state.nodes.filter(isFieldNode).sort((a, b) => a.data.order - b.data.order);
 
   const slots: GenericTemplateSlot[] = gameNodes.map(node => {
     // Derive stage name, type, and category from the parent stage node.
@@ -198,7 +202,7 @@ export function genericizeFlowState(state: FlowState, name: string, description:
     name,
     description,
     num_teams: state.globalTeams.length,
-    num_fields: state.fields.length,
+    num_fields: fieldsList.length,
     num_groups: state.globalTeamGroups.length,
     game_duration: state.metadata?.game_duration || 70,
     sharing,


### PR DESCRIPTION
## Summary
- `genericizeFlowState` (gameday_designer/src/utils/templateMapper.ts) derived `num_fields` and each game slot's field index from the `fields` metadata array, but that array is only kept in sync by the tournament-generator/import flows — the "Add Field" button and automatic hierarchy creation never populate it, so hand-built schedules end up with an empty `fields` array despite real field container nodes existing on the canvas.
- This made "Save as Template" send `num_fields: 0`, which the backend rejects with a 400 ("num_fields must be a positive integer"), and silently collapsed every game slot onto `field: 1` regardless of its actual field.
- Fix: derive field count/order from the actual field container nodes in `state.nodes` instead of the stale `fields` array.

Reproduced live on stage.leaguesphere.app/gamedays/gameday/design/designer/895 (Save as Template → 400, all 16 slots reported as field 1 despite the gameday having 4 fields).

## Test plan
- [x] Added a failing test reproducing the exact production data shape (empty `fields`, real field/stage/game nodes across 2 fields); confirmed it failed with `num_fields: 0` before the fix
- [x] Fix applied; new test passes (`num_fields: 2`, slots correctly attributed to field 1 / field 2)
- [x] Full `gameday_designer` suite: 1144 passed, 1 pre-existing unrelated failure (confirmed present on master before this change — jsdom CSS rendering quirk in ListCanvas.test.tsx, unrelated to this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)