### PR TITLE
ci: skip build/test jobs on release-please branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,30 +707,44 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - e2e:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - scorecard_js:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - liveticker_js:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - passcheck_js:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - gameday_designer_js:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - journey_dashboard_js:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
 
       - build_backend:
           requires:
@@ -739,6 +753,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - build_frontend:
           requires:
             - scorecard_js
@@ -749,6 +765,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
 
       - test_backend_image:
           requires:
@@ -756,12 +774,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - test_frontend_image:
           requires:
             - build_frontend
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - check_migrations:
           context: staging
           requires:
@@ -769,6 +791,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
       - test_compose_network:
           requires:
             - build_backend
@@ -779,6 +803,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: release-please--branches--master
 
       - ensure_draft_release:
           filters:


### PR DESCRIPTION
## Summary
- The `release-please--branches--master` branch is CI-exercised twice already (once on its PR, once again when it's merged to `master`), plus the deploy workflow runs a third time on the resulting tag — running full CI a fourth time on the branch push itself is redundant.
- Adds `branches: ignore: release-please--branches--master` to the 13 build/test jobs (`python`, `e2e`, the five `*_js` jobs, `build_backend`, `build_frontend`, `test_backend_image`, `test_frontend_image`, `check_migrations`, `test_compose_network`) that currently run on every branch push.
- Tag-triggered deploy/release jobs are untouched (they already use `branches: ignore: /.*/`, so this doesn't affect them).

## Test plan
- [x] `circleci config validate .circleci/config.yml` passes
- [x] Diff reviewed — only the 13 always-run jobs gained the branch filter; deploy/release jobs unchanged
- [ ] Confirm next release-please branch push skips the workflow entirely in the CircleCI UI