### PR TITLE
ci: skip master-push run instead of stubbing release-please checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -699,25 +699,19 @@ jobs:
               --header "Circle-Token: ${CIRCLE_API_APPROVE_TOKEN}" \
               "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/approve/${approval_request_id}"
 
-  # Stand-in for the 3 checks required by branch protection on the
-  # release-please branch: that branch only ever contains a version bump +
-  # changelog (never code), and its content was already exercised by CI on
-  # the master-merge push that triggered release-please. See the
-  # `release_please_checks` workflow below.
-  noop:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - run:
-          name: Skip (release-please branch already verified pre-merge)
-          command: echo "Skipping - covered by required checks on the prior master-merge CI run"
-
 workflows:
   version: 2
   build_test_deploy:
+    # Skip the master-push run: merges are PR-only (ruleset requires a PR)
+    # and required status checks must be up to date with master before
+    # merging, so whatever lands on master was just CI'd against that exact
+    # base a moment earlier - a second full run on the merge commit itself
+    # adds nothing. Still runs on every other branch (including the
+    # release-please branch, so its required checks post normally) and on
+    # tags (via each job's own `tags` filter, for deploys).
     when:
       not:
-        equal: [ << pipeline.git.branch >>, "release-please--branches--master" ]
+        equal: [ << pipeline.git.branch >>, "master" ]
     jobs:
       - python:
           filters:
@@ -881,17 +875,3 @@ workflows:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/
-
-  # Satisfies the 3 branch-protection-required checks on the release-please
-  # branch without repeating the real build_test_deploy workflow. See the
-  # `noop` job comment above for why this is safe.
-  release_please_checks:
-    when:
-      equal: [ << pipeline.git.branch >>, "release-please--branches--master" ]
-    jobs:
-      - noop:
-          name: e2e
-      - noop:
-          name: check_migrations
-      - noop:
-          name: test_compose_network


### PR DESCRIPTION
## Summary
Supersedes #1706's approach after discussion: the master-push CI run turned out to be the actually-redundant one, not the release-please branch.

- The master ruleset requires merges to go through a PR, and `strict_required_status_checks_policy: true` means a PR must be up to date with master before it's allowed to merge. So whatever lands on master was tested against that exact base moments earlier — a second full `build_test_deploy` run on the merge commit adds nothing beyond a thin safety net for admin bypass-merges or merge races.
- `build_test_deploy`'s `when` now skips branch `master` instead of `release-please--branches--master`.
- The release-please branch now runs the real pipeline again — the `noop`/`release_please_checks` stub workflow from #1706 is removed. This is simpler and safer: the 3 required checks (`test_compose_network`, `check_migrations`, `e2e`) are produced by actual work again instead of relying on a hand-maintained stub staying in sync with whatever `test_compose_network` transitively requires.
- Net effect: still 1 of 4 redundant runs saved, just on a different (safer) axis.

## Test plan
- [x] `circleci config validate .circleci/config.yml` passes
- [x] Diff reviewed — `noop` job and `release_please_checks` workflow fully removed, only the `when` condition's branch name changed
- [ ] Confirm on the next master merge: no CircleCI pipeline triggers for that push
- [ ] Confirm on the next release-please branch push: full `build_test_deploy` runs and all 3 required checks post normally, auto-merge proceeds