### PR TITLE
ci: reactivate GitHub Actions workflow for master branch

### DIFF
--- a/.github/workflows/ci_branch.yaml
+++ b/.github/workflows/ci_branch.yaml
@@ -1,10 +1,13 @@
-# NOTE: GitHub Actions are being deactivated in favor of CircleCI due to pricing changes.
-# Reference: https://github.com/resources/insights/2026-pricing-changes-for-github-actions
+# GitHub Actions companion workflow for master branch.
+# Mirrors CircleCI's build_test_deploy workflow on master pushes (build + test only, no deploy).
+# CircleCI remains the primary CI; this provides a safety-net second opinion on master.
 name: 🏗️🧪🍂 Build & Test branches
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
 on:
   workflow_dispatch:
-#  push:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
Re-enables the `ci_branch.yaml` GitHub Actions workflow to trigger on pushes to `master`.

This mirrors CircleCI's build+test workflow on master as a companion safety-net. Deploy steps are not included — CircleCI remains the primary CI for deployments.

Generated with Qwen Code (2-shotted by Qwen-Coder)