### PR TITLE
fix(gameday-designer): preserve winner/loser refs when re-importing a schedule

### DIFF
--- a/gameday_designer/src/utils/__tests__/flowchartImport.test.ts
+++ b/gameday_designer/src/utils/__tests__/flowchartImport.test.ts
@@ -96,6 +96,13 @@ describe('Flowchart Import Utility', () => {
 
       // Check that edges have correct sourceHandle
       expect(gameToGameEdges.every((e) => e.sourceHandle === 'winner')).toBe(true);
+
+      // The game node's own data must carry the dynamic reference too, not just the edge -
+      // GameTable and exportToScheduleJson both read data.homeTeamDynamic/awayTeamDynamic
+      // directly and never re-derive it from edges.
+      const finalGame = nodes.find((n) => isGameNode(n) && n.data.standing === 'P1');
+      expect(finalGame?.data.homeTeamDynamic).toEqual({ type: 'winner', matchName: 'HF1' });
+      expect(finalGame?.data.awayTeamDynamic).toEqual({ type: 'winner', matchName: 'HF2' });
     });
 
     it('imports loser references correctly', () => {
@@ -137,6 +144,11 @@ describe('Flowchart Import Utility', () => {
       // Check loser edges
       const gameToGameEdges = edges.filter(isGameToGameEdge);
       expect(gameToGameEdges.every((e) => e.sourceHandle === 'loser')).toBe(true);
+
+      const { nodes } = result.state!;
+      const p3Game = nodes.find((n) => isGameNode(n) && n.data.standing === 'P3');
+      expect(p3Game?.data.homeTeamDynamic).toEqual({ type: 'loser', matchName: 'HF1' });
+      expect(p3Game?.data.awayTeamDynamic).toEqual({ type: 'loser', matchName: 'HF2' });
     });
 
     it('imports break_after correctly', () => {

--- a/gameday_designer/src/utils/flowchartImport.ts
+++ b/gameday_designer/src/utils/flowchartImport.ts
@@ -194,6 +194,16 @@ export function importFromScheduleJson(json: unknown): ImportResult {
               slot as GameInputHandle
             );
             edges.push(edge);
+
+            // Mirror the edge onto the game node's own data. GameTable and
+            // exportToScheduleJson read data.homeTeamDynamic/awayTeamDynamic
+            // directly and never re-derive it from edges (that only happens
+            // via the useEdgesState mutators the interactive canvas uses).
+            if (slot === 'home') {
+              gameNode.data.homeTeamDynamic = parsed;
+            } else {
+              gameNode.data.awayTeamDynamic = parsed;
+            }
           } else {
             warnings.push(
               `Game "${game.standing}": Referenced match "${parsed.matchName}" not found`


### PR DESCRIPTION
## Summary
- Reproduced by exporting gameday 898's schedule and importing it into gameday 903 on stage: the imported schedule was not the same as the source.
- Root cause: `importFromScheduleJson` (rewritten in #1717 to build the v2 container hierarchy) creates a `GameToGameEdge` for every winner/loser team reference, but never writes the matching `homeTeamDynamic`/`awayTeamDynamic` onto the game node's own `data`. `GameTable` and `exportToScheduleJson` both read that data field directly and never re-derive it from edges (only the interactive canvas mutators in `useEdgesState.ts` keep it in sync). So every "Gewinner X"/"Verlierer X" slot showed up empty immediately after import, and re-exporting turned it into `"TBD"`.
- Fix: mirror the parsed winner/loser reference onto `gameNode.data.homeTeamDynamic`/`awayTeamDynamic` at the same point the edge is created during import.
- Note: while verifying against the real downloaded fixture, two games (`VF 1`, `VF 4`) reference a match called `"Game 1"`/`"Game 2"` that doesn't correspond to any standing in the file — that's a pre-existing dangling reference in the source gameday's data (not something import/export can resolve), separate from this bug.

## Test plan
- [x] Added failing-first regression tests in `flowchartImport.test.ts` asserting `data.homeTeamDynamic`/`awayTeamDynamic` are populated for winner and loser references; confirmed they failed before the fix and pass after.
- [x] `npx vitest run` in `gameday_designer` — 1108 tests, only pre-existing unrelated failure (`ListCanvas.test.tsx` empty-state icon font-size, a jsdom quirk, fails identically on `master`).
- [x] Verified end-to-end against the actual downloaded fixture (`schedule_16_games_4_fields.json` from gameday 898): import → export now round-trips the winner/loser references correctly.
- [x] `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)