### PR TITLE
fix(gameday-designer): allow selecting any team for External Officials

### DIFF
--- a/gameday_designer/src/api/__tests__/designerApi.test.ts
+++ b/gameday_designer/src/api/__tests__/designerApi.test.ts
@@ -513,4 +513,40 @@ describe('DesignerApi', () => {
       expect(result.gamedays).toHaveLength(2);
     });
   });
+
+  describe('getLeagueTeams', () => {
+    it('should fetch teams scoped to the gameday league by default', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [{ id: 1, name: 'Team A' }] });
+
+      const result = await designerApi.getLeagueTeams(42);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/gamedays/42/league-teams/',
+        { params: undefined }
+      );
+      expect(result).toEqual([{ id: 1, name: 'Team A' }]);
+    });
+
+    it('should request scope=all when allTeams is true', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      await designerApi.getLeagueTeams(42, { allTeams: true });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/gamedays/42/league-teams/',
+        { params: { scope: 'all' } }
+      );
+    });
+
+    it('should not request scope=all when allTeams is false', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+      await designerApi.getLeagueTeams(42, { allTeams: false });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+        '/gamedays/42/league-teams/',
+        { params: undefined }
+      );
+    });
+  });
 });

--- a/gameday_designer/src/api/designerApi.ts
+++ b/gameday_designer/src/api/designerApi.ts
@@ -271,9 +271,17 @@ class DesignerApi {
     return response.data;
   }
 
-  async getLeagueTeams(gamedayId: number): Promise<TeamRecord[]> {
+  /**
+   * List teams selectable for a gameday.
+   *
+   * @param options.allTeams - Bypass the gameday's own league restriction and
+   * return every team. Used for external officials, who are typically not
+   * part of the gameday's own league.
+   */
+  async getLeagueTeams(gamedayId: number, options?: { allTeams?: boolean }): Promise<TeamRecord[]> {
     const response = await this.client.get<TeamRecord[]>(
-      `/gamedays/${gamedayId}/league-teams/`
+      `/gamedays/${gamedayId}/league-teams/`,
+      { params: options?.allTeams ? { scope: 'all' } : undefined }
     );
     return response.data;
   }

--- a/gameday_designer/src/components/ListDesignerApp.tsx
+++ b/gameday_designer/src/components/ListDesignerApp.tsx
@@ -667,6 +667,7 @@ const ListDesignerApp: React.FC = () => {
         gamedayId={id ? parseInt(id) : 0}
         mode={teamSelectionContext?.side === 'group' ? 'group' : 'single'}
         preselectedTeams={teamSelectionContext?.side === 'group' ? flowState.globalTeams.filter(t => t.groupId === teamSelectionContext.slotId) : []}
+        allTeams={teamSelectionContext?.slotId === 'group-officials'}
       />
 
       <TemplateLibraryModal

--- a/gameday_designer/src/components/__tests__/ListDesignerApp.test.tsx
+++ b/gameday_designer/src/components/__tests__/ListDesignerApp.test.tsx
@@ -20,9 +20,13 @@ vi.mock('../../hooks/useFlowState', () => ({
 
 // Mock TeamSelectionModal to expose a trigger button for tests
 vi.mock('../modals/TeamSelectionModal', () => ({
-  default: ({ show, onSelect }: { show: boolean; onSelect: (teams: GlobalTeam[]) => void }) =>
+  default: ({ show, onSelect, allTeams }: { show: boolean; onSelect: (teams: GlobalTeam[]) => void; allTeams?: boolean }) =>
     show ? (
-      <button data-testid="mock-team-select" onClick={() => onSelect([{ id: '99', label: 'Replaced Team', groupId: null, order: 0, color: '#000' }])}>
+      <button
+        data-testid="mock-team-select"
+        data-all-teams={String(!!allTeams)}
+        onClick={() => onSelect([{ id: '99', label: 'Replaced Team', groupId: null, order: 0, color: '#000' }])}
+      >
         Select Team
       </button>
     ) : null,
@@ -257,6 +261,40 @@ describe('ListDesignerApp', () => {
 
       expect(mockHandlers.handleReplaceGlobalTeam).toHaveBeenCalledWith('team-1', { id: 99, text: 'Replaced Team' });
       expect(mockHandlers.handleAssignTeam).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('External officials team picker', () => {
+    it('requests all teams (not just the league) when adding to the External Officials group', async () => {
+      const officialsGroup: GlobalTeamGroup = { id: 'group-officials', name: 'External Officials', order: -1 };
+      (useFlowState as Mock).mockReturnValue({
+        ...defaultFlowState,
+        globalTeams: [],
+        globalTeamGroups: [officialsGroup],
+      });
+      renderApp();
+
+      const addTeamBtn = await screen.findByTestId('add-team-button');
+      await act(async () => { addTeamBtn.click(); });
+
+      const selectBtn = await screen.findByTestId('mock-team-select');
+      expect(selectBtn).toHaveAttribute('data-all-teams', 'true');
+    });
+
+    it('keeps the league restriction for a regular team group', async () => {
+      const regularGroup: GlobalTeamGroup = { id: 'group-1', name: 'Gruppe A', order: 0 };
+      (useFlowState as Mock).mockReturnValue({
+        ...defaultFlowState,
+        globalTeams: [],
+        globalTeamGroups: [regularGroup],
+      });
+      renderApp();
+
+      const addTeamBtn = await screen.findByTestId('add-team-button');
+      await act(async () => { addTeamBtn.click(); });
+
+      const selectBtn = await screen.findByTestId('mock-team-select');
+      expect(selectBtn).toHaveAttribute('data-all-teams', 'false');
     });
   });
 

--- a/gameday_designer/src/components/modals/TeamSelectionModal.tsx
+++ b/gameday_designer/src/components/modals/TeamSelectionModal.tsx
@@ -14,6 +14,8 @@ export interface TeamSelectionModalProps {
   gamedayId?: number;
   mode?: 'single' | 'group';
   preselectedTeams?: GlobalTeam[];
+  /** Bypass the gameday's own league restriction, e.g. for external officials. */
+  allTeams?: boolean;
 }
 
 const TeamSelectionModal: React.FC<TeamSelectionModalProps> = ({
@@ -23,6 +25,7 @@ const TeamSelectionModal: React.FC<TeamSelectionModalProps> = ({
   gamedayId = 0,
   mode = 'single',
   preselectedTeams = [],
+  allTeams = false,
 }) => {
   const [availableTeams, setAvailableTeams] = useState<GlobalTeam[]>([]);
   const [loading, setLoading] = useState(false);
@@ -33,7 +36,7 @@ const TeamSelectionModal: React.FC<TeamSelectionModalProps> = ({
     const loadTeams = async () => {
       setLoading(true);
       try {
-        const teams = await designerApi.getLeagueTeams(gamedayId);
+        const teams = await designerApi.getLeagueTeams(gamedayId, { allTeams });
         const globalTeams = teams.map((t, i) => ({
           id: String(t.id),
           label: t.name,
@@ -51,7 +54,7 @@ const TeamSelectionModal: React.FC<TeamSelectionModalProps> = ({
     };
 
     loadTeams();
-  }, [show, gamedayId]);
+  }, [show, gamedayId, allTeams]);
 
   const handleConfirm = (selectedTeams: GlobalTeam[]) => {
     onSelect(selectedTeams);

--- a/gameday_designer/tests/test_team_creation_api.py
+++ b/gameday_designer/tests/test_team_creation_api.py
@@ -209,6 +209,25 @@ class TestLeagueTeamsView:
         assert response.status_code == status.HTTP_200_OK
         assert response.data == []
 
+    def test_scope_all_bypasses_league_restriction(
+        self, api_client, staff_user, gameday, teams
+    ):
+        """?scope=all returns every team, not just the ones in the gameday's own league -
+        used for picking external officials from outside the gameday's league."""
+        slt = SeasonLeagueTeam.objects.create(
+            season=gameday.season, league=gameday.league
+        )
+        slt.teams.set(teams[:3])
+        api_client.force_authenticate(user=staff_user)
+
+        scoped_response = api_client.get(self.url(gameday.pk))
+        all_response = api_client.get(self.url(gameday.pk), {"scope": "all"})
+
+        assert len(scoped_response.data) == 3
+        assert len(all_response.data) == len(teams)
+        returned_ids = {item["id"] for item in all_response.data}
+        assert returned_ids == {t.pk for t in teams}
+
     def test_returns_404_for_unknown_gameday(self, api_client, staff_user):
         """Returns 404 when gameday does not exist."""
         api_client.force_authenticate(user=staff_user)

--- a/gameday_designer/views.py
+++ b/gameday_designer/views.py
@@ -597,6 +597,10 @@ class LeagueTeamsView(APIView):
     GET /api/designer/gamedays/<gameday_id>/league-teams/
     Returns teams in the gameday's league+season via SeasonLeagueTeam.
     Falls back to all teams if no SeasonLeagueTeam is configured.
+
+    Pass ?scope=all to skip the league restriction and return all teams
+    regardless of SeasonLeagueTeam - used when picking teams that aren't
+    part of the gameday's own league, e.g. external officials.
     """
 
     permission_classes = [IsAuthenticated]
@@ -605,9 +609,14 @@ class LeagueTeamsView(APIView):
         from gamedays.models import SeasonLeagueTeam, Team
 
         gameday = get_object_or_404(Gameday, pk=gameday_id)
-        slt = SeasonLeagueTeam.objects.filter(
-            season=gameday.season, league=gameday.league
-        ).first()
+        scope_all = request.query_params.get("scope") == "all"
+        slt = (
+            None
+            if scope_all
+            else SeasonLeagueTeam.objects.filter(
+                season=gameday.season, league=gameday.league
+            ).first()
+        )
 
         if slt:
             teams = slt.teams.select_related("association").all()


### PR DESCRIPTION
## Summary
Fixes #1731.

The Team Pool's "External Officials" group exists specifically to hold officiating teams from *outside* the gameday's own league/tournament, but clicking "Add Team" inside it opens the same "Select Teams" picker used everywhere else, which is scoped to the gameday's own league via `SeasonLeagueTeam` - so a team from a different league or association could never actually be selected as an official.

Verified live on `stage.leaguesphere.app`, gameday 898 (league AFVBy/Bayernpokal): the picker's "All Teams" / "Local Teams" / "Other Teams" / "AFVBY" chips and search box all filter over the same fixed, league-scoped list of 16 teams - searching for a team known to exist in a different league returns "No teams match your search or filter."

## Fix
- `LeagueTeamsView` (`gameday_designer/views.py`) now accepts `?scope=all`, which skips the `SeasonLeagueTeam` lookup and returns every non-dummy team (reusing the same fallback query already used when no `SeasonLeagueTeam` is configured).
- `designerApi.getLeagueTeams` takes an optional `{ allTeams: boolean }` and forwards it as `?scope=all`.
- `TeamSelectionModal` takes a new `allTeams` prop and requests all teams when set.
- `ListDesignerApp` passes `allTeams={true}` **only** when the picker is opened for the `group-officials` group - every other team-selection flow (assigning real teams to bracket placeholders, adding teams to a regular team group) keeps the existing league-scoped behavior unchanged.

## Test plan
- [x] Backend: new test `test_scope_all_bypasses_league_restriction` - confirmed failing before the view change, passing after. Full `gameday_designer` pytest suite (229 tests) green, run locally against sqlite (`DJANGO_SETTINGS_MODULE=test_settings`).
- [x] Frontend: new `designerApi.getLeagueTeams` tests for the `allTeams` param; new `ListDesignerApp` tests confirming `allTeams=true` only for the `group-officials` picker and `false` for a regular group - confirmed failing before the `ListDesignerApp` wiring change, passing after.
- [x] Full `vitest run` - 1112/1113 passing (1 pre-existing, unrelated jsdom font-size failure that also fails identically on `master`).
- [x] `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)