### PR TITLE
fix(gameday-designer): drop dangling dynamic team references from applied templates

### DIFF
--- a/gameday_designer/src/utils/__tests__/templateMapper.test.ts
+++ b/gameday_designer/src/utils/__tests__/templateMapper.test.ts
@@ -157,4 +157,67 @@ describe('templateMapper', () => {
     expect(fieldByStanding.get('A1')).toBe(1);
     expect(fieldByStanding.get('B1')).toBe(2);
   });
+
+  describe('unresolvable winner/loser references', () => {
+    const groups: GlobalTeamGroup[] = [{ id: 'g1', name: 'Group A', order: 0 }];
+    const teams: GlobalTeam[] = [
+      { id: 't1', label: 'Team 1', groupId: 'g1', order: 0 },
+      { id: 't2', label: 'Team 2', groupId: 'g1', order: 1 },
+    ];
+
+    const baseSlot = {
+      field: 1, slot_order: 1, stage: 'Preliminary', stage_type: 'STANDARD' as const,
+      stage_category: 'preliminary' as const, break_after: 0,
+      home_group: 0, home_team: 0, home_reference: '',
+      away_group: 0, away_team: 1, away_reference: '',
+      official_group: null, official_team: null, official_reference: '',
+      start_time: '', manual_time: false,
+    };
+
+    it('wires an edge and keeps the dynamic reference when the source standing exists', () => {
+      const template = {
+        name: 'Test', description: '', num_teams: 2, num_fields: 1, num_groups: 1,
+        game_duration: 15, sharing: 'PRIVATE' as const,
+        slots: [
+          { ...baseSlot, slot_order: 1, standing: 'AF 1' },
+          { ...baseSlot, slot_order: 2, standing: 'VF 1', home_reference: 'Winner AF 1', home_group: null, home_team: null },
+        ],
+      };
+      const currentState: FlowState = {
+        nodes: [], edges: [], globalTeams: teams, globalTeamGroups: groups, metadata: null,
+      } as unknown as FlowState;
+
+      const result = applyGenericTemplate(template, currentState);
+
+      const vf1 = result.nodes.filter(isGameNode).find(n => n.data.standing === 'VF 1')!;
+      expect(vf1.data.homeTeamDynamic).toEqual({ type: 'winner', matchName: 'AF 1' });
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0].targetHandle).toBe('home');
+    });
+
+    it('clears the dynamic reference instead of leaving a dangling matchName when the source standing does not exist', () => {
+      // Reproduces production bug (gameday 898, stage): a template slot's
+      // home_reference pointed at a standing ("Game 1") that doesn't match any
+      // slot's own `standing` in the same template. No edge could be wired,
+      // but homeTeamDynamic was set unconditionally regardless - so the
+      // canvas showed the slot as unassigned while export still emitted
+      // "Gewinner Game 1" for a match that doesn't exist anywhere.
+      const template = {
+        name: 'Test', description: '', num_teams: 2, num_fields: 1, num_groups: 1,
+        game_duration: 15, sharing: 'PRIVATE' as const,
+        slots: [
+          { ...baseSlot, slot_order: 1, standing: 'VF 1', home_reference: 'Winner Game 1', home_group: null, home_team: null },
+        ],
+      };
+      const currentState: FlowState = {
+        nodes: [], edges: [], globalTeams: teams, globalTeamGroups: groups, metadata: null,
+      } as unknown as FlowState;
+
+      const result = applyGenericTemplate(template, currentState);
+
+      const vf1 = result.nodes.filter(isGameNode).find(n => n.data.standing === 'VF 1')!;
+      expect(vf1.data.homeTeamDynamic).toBeNull();
+      expect(result.edges.filter(e => e.targetHandle === 'home')).toHaveLength(0);
+    });
+  });
 });

--- a/gameday_designer/src/utils/templateMapper.ts
+++ b/gameday_designer/src/utils/templateMapper.ts
@@ -394,6 +394,8 @@ export function applyGenericTemplate(template: GenericTemplate, currentState: Fl
         : targetGame.data.awayTeamDynamic;
       if (!dynamicRef) continue;
 
+      let resolved = false;
+
       if (isWinnerReference(dynamicRef) || isLoserReference(dynamicRef)) {
         const sourceGame = allGameNodes.find(g => g.data.standing === dynamicRef.matchName);
         if (sourceGame) {
@@ -404,6 +406,7 @@ export function applyGenericTemplate(template: GenericTemplate, currentState: Fl
             targetGame.id,
             slot
           ));
+          resolved = true;
         }
       } else if (isRankReference(dynamicRef) || isGroupRankReference(dynamicRef)) {
         const sourceStage = newNodes.find(n => isStageNode(n) && n.id === dynamicRef.stageId);
@@ -416,6 +419,21 @@ export function applyGenericTemplate(template: GenericTemplate, currentState: Fl
             slot,
             isGroupRankReference(dynamicRef) ? dynamicRef.groupName : undefined
           ));
+          resolved = true;
+        }
+      }
+
+      // A dynamic reference that can't be resolved to a real source game/stage
+      // (e.g. a template slot's home_reference/away_reference pointing at a
+      // standing that doesn't match any slot in the same template) must not be
+      // left as data with no backing edge - GameTable and exportToScheduleJson
+      // read this field directly and would otherwise show/export a phantom
+      // "Winner of X" for a match that doesn't exist.
+      if (!resolved) {
+        if (slot === 'home') {
+          targetGame.data.homeTeamDynamic = null;
+        } else {
+          targetGame.data.awayTeamDynamic = null;
         }
       }
     }


### PR DESCRIPTION
## Summary
Fixes #1729.

Root cause found by fetching gameday 898's raw designer state (`GET /api/gamedays/898/designer-state/`): `VF 1` and `VF 4` each have exactly **one** `GameToGameEdge` (their away slot) instead of two. Their home slot's `homeTeamDynamic` is still set to `{type: "winner", matchName: "Game 1"}` / `{"Game 2"}` - names that don't match any game's `standing` anywhere in the schedule (all 8 round-of-16 games are named `AF 1`-`AF 8`).

`applyGenericTemplate` (`gameday_designer/src/utils/templateMapper.ts`) sets a game node's `homeTeamDynamic`/`awayTeamDynamic` directly from the template slot's `home_reference`/`away_reference` string at node-creation time, **unconditionally** - independent of whether the later "rebuild edges" pass can actually find a matching source game/stage by `standing`. When it can't, the edge is correctly skipped, but the stale reference is left sitting in `data.homeTeamDynamic`.

This is exactly why the canvas and the export disagreed: `GameTable`'s dropdown resolves the current selection from the **edge** (`findSourceGameForReference`), so it correctly showed "-- Select Team --" for `VF 1`'s home slot on the live stage designer. But `exportToScheduleJson`'s `deriveTeamReference` reads `data.homeTeamDynamic` **directly**, so it emitted `"Gewinner Game 1"` for a match that doesn't exist - the canvas and the exported JSON told two different stories from the same broken state.

## Fix
In the "rebuild edges" pass, when a winner/loser/rank reference can't be resolved to a real source game or stage, clear the corresponding `homeTeamDynamic`/`awayTeamDynamic` instead of leaving it set. This makes the slot consistently show as unassigned everywhere (canvas, export, and `exportToScheduleJson`'s "incomplete team assignments" validation), instead of exporting a phantom label for a match that was never wired.

## Scope / what this does NOT do
This prevents the issue for templates applied **going forward**. It does **not** retroactively repair gameday 898's own already-broken `designer_state` - fixing that requires a tournament organizer to manually reselect `VF 1`'s and `VF 4`'s home team via the UI (now that the picker correctly shows them as unassigned). I did not script a data repair for this - manual production data edits are out of scope for this PR.

## Test plan
- [x] New tests in `templateMapper.test.ts`: one confirms edges + dynamic refs are still wired correctly when the reference resolves; one reproduces the exact production shape (unresolvable `home_reference`) and confirms it now clears to `null` instead of leaving a dangling `matchName` - confirmed failing before the fix, passing after.
- [x] Full `vitest run` - 1114/1115 passing (1 pre-existing, unrelated jsdom font-size failure that also fails identically on `master`).
- [x] `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)