### PR TITLE
fix(gameday_designer): resolve master typecheck regression, add GH Actions typecheck safety net

### DIFF
--- a/.github/workflows/part_node_test_matrix.yaml
+++ b/.github/workflows/part_node_test_matrix.yaml
@@ -37,6 +37,9 @@ jobs:
           npm ci
           npm run test:coverage
 
+      - name: 🔎 Typecheck ${{ matrix.project }}
+        run: npm run typecheck --if-present
+
       - name: 📊 Upload Coverage to Codecov
         env:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/gameday_designer/src/utils/__tests__/flowchartImport.test.ts
+++ b/gameday_designer/src/utils/__tests__/flowchartImport.test.ts
@@ -8,6 +8,7 @@ import {
   validateScheduleJson,
 } from '../flowchartImport';
 import { isGameNode, isGameToGameEdge, isFieldNode, isStageNode } from '../../types/flowchart';
+import type { GameNode } from '../../types/flowchart';
 
 describe('Flowchart Import Utility', () => {
   describe('importFromScheduleJson', () => {
@@ -100,7 +101,7 @@ describe('Flowchart Import Utility', () => {
       // The game node's own data must carry the dynamic reference too, not just the edge -
       // GameTable and exportToScheduleJson both read data.homeTeamDynamic/awayTeamDynamic
       // directly and never re-derive it from edges.
-      const finalGame = nodes.find((n) => isGameNode(n) && n.data.standing === 'P1');
+      const finalGame = nodes.find((n) => isGameNode(n) && n.data.standing === 'P1') as GameNode | undefined;
       expect(finalGame?.data.homeTeamDynamic).toEqual({ type: 'winner', matchName: 'HF1' });
       expect(finalGame?.data.awayTeamDynamic).toEqual({ type: 'winner', matchName: 'HF2' });
     });
@@ -146,7 +147,7 @@ describe('Flowchart Import Utility', () => {
       expect(gameToGameEdges.every((e) => e.sourceHandle === 'loser')).toBe(true);
 
       const { nodes } = result.state!;
-      const p3Game = nodes.find((n) => isGameNode(n) && n.data.standing === 'P3');
+      const p3Game = nodes.find((n) => isGameNode(n) && n.data.standing === 'P3') as GameNode | undefined;
       expect(p3Game?.data.homeTeamDynamic).toEqual({ type: 'loser', matchName: 'HF1' });
       expect(p3Game?.data.awayTeamDynamic).toEqual({ type: 'loser', matchName: 'HF2' });
     });

--- a/gameday_designer/src/utils/flowchartImport.ts
+++ b/gameday_designer/src/utils/flowchartImport.ts
@@ -173,6 +173,7 @@ export function importFromScheduleJson(json: unknown): ImportResult {
       // Find the game node
       const gameNode = nodes.find((n) => n.id === gameId);
       if (!gameNode) continue;
+      const gameData = gameNode.data as GameNodeData;
 
       // Process home and away teams
       for (const [refStr, slot] of [
@@ -201,9 +202,9 @@ export function importFromScheduleJson(json: unknown): ImportResult {
             // directly and never re-derive it from edges (that only happens
             // via the useEdgesState mutators the interactive canvas uses).
             if (slot === 'home') {
-              gameNode.data.homeTeamDynamic = parsed;
+              gameData.homeTeamDynamic = parsed;
             } else {
-              gameNode.data.awayTeamDynamic = parsed;
+              gameData.awayTeamDynamic = parsed;
             }
           } else {
             warnings.push(
@@ -215,7 +216,6 @@ export function importFromScheduleJson(json: unknown): ImportResult {
           const teamId = teamLabelMap.get(parsed.name);
           if (teamId) {
             // Update game node with team assignment
-            const gameData = gameNode.data as GameNodeData;
             if (slot === 'home') {
               gameData.homeTeamId = teamId;
             } else {

--- a/gameday_designer/src/utils/templateMapper.ts
+++ b/gameday_designer/src/utils/templateMapper.ts
@@ -9,14 +9,14 @@ export interface GenericTemplateSlot {
   stage_type: 'STANDARD' | 'RANKING';
   stage_category: StageCategory;
   standing: string;
-  home_group?: number;
-  home_team?: number;
+  home_group?: number | null;
+  home_team?: number | null;
   home_reference?: string;
-  away_group?: number;
-  away_team?: number;
+  away_group?: number | null;
+  away_team?: number | null;
   away_reference?: string;
-  official_group?: number;
-  official_team?: number;
+  official_group?: number | null;
+  official_team?: number | null;
   official_reference?: string;
   break_after: number;
   start_time?: string;
@@ -243,8 +243,8 @@ export function applyGenericTemplate(template: GenericTemplate, currentState: Fl
   }
 
   // Helper to get actual team ID from group/team index
-  const getTeamId = (groupIdx: number | undefined, teamIdx: number | undefined): string | null => {
-    if (groupIdx === undefined || teamIdx === undefined) return null;
+  const getTeamId = (groupIdx: number | null | undefined, teamIdx: number | null | undefined): string | null => {
+    if (groupIdx == null || teamIdx == null) return null;
     const group = newGroups[groupIdx];
     if (!group) return null;
     const teamsInGroup = newTeams.filter(t => t.groupId === group.id).sort((a, b) => a.order - b.order);


### PR DESCRIPTION
## Problem

`master` currently fails `tsc --noEmit` in `gameday_designer` with 8 errors. Not caused by any recent PR's own diff — it's a stale-base merge gap:

- **#1727** (merged 2026-07-31 22:19) added code in `flowchartImport.ts` accessing `gameNode.data.homeTeamDynamic`/`awayTeamDynamic` on a `.find()` result typed as the general `FlowNode` union — already type-incorrect the moment it was written, but invisible because `tsc --noEmit` was still silently skipping all `src/` files (the exact bug #1719 fixed).
- **#1719**'s branch was cut *before* #1727 merged and was never rebased onto the master commits that landed in between. When it was squash-merged, GitHub allowed it (`mergeStateStatus: CLEAN`) despite the stale base, because master's ruleset has `strict_required_status_checks_policy: false` — branches aren't required to be up to date with base before merging.
- Net result: the combination of "#1719 turns typechecking on" + "#1727's code, never typechecked against a working `tsc`" was never validated together before landing on master.

## Fix

- `flowchartImport.ts`: narrow `gameNode.data` to `GameNodeData` once via the same `as GameNodeData` cast already used lower in the function, instead of accessing the untyped `FlowNodeData` union directly.
- `flowchartImport.test.ts`: same `.find()` narrowing issue in two tests — `isGameNode()` used as a `.find()` predicate doesn't narrow the return type without an explicit type predicate.
- `templateMapper.ts`: `GenericTemplateSlot`'s group/team index fields were typed `number | undefined`, but real template data (and these tests) use `null` for unset fields — matching the established `TemplateSlot` API type (`number | null`). Widened to match, and updated `getTeamId`'s null-check accordingly.

## CI safety net

Also adds a real typecheck step to the GitHub Actions master safety-net workflow (`part_node_test_matrix.yaml`, invoked by `ci_branch.yaml` on every push to `master`).

This exact regression is why it's needed:
- CircleCI intentionally **skips re-running on master pushes** (see the comment in `.circleci/config.yml`), on the assumption that the base branch's required-status-checks are strict/up-to-date before merge — which isn't actually enforced (see above).
- The existing GH Actions safety net already runs on every master push, but its "Building" step only runs `vite build`, which does **not** type-check (esbuild ignores type errors) — so it never would have caught this either.

`npm run typecheck --if-present` is used since only 3 of the 5 frontend apps (`gameday_designer`, `passcheck`, `journey_dashboard`) have a `typecheck` script; the other two (`scorecard`, `liveticker`) are plain JS.

## Verification

- `tsc --noEmit`: clean (was 8 errors)
- `eslint`: clean
- Full `gameday_designer` test suite: 1115/1115 passing
- Confirmed `npm run typecheck --if-present` exits 0 for apps without the script (tested against `scorecard`)

🤖 Generated with [Claude Code](https://claude.ai/code)