### PR TITLE
fix(journey): exclude draft gamedays from progress dashboard

### DIFF
--- a/journey/api/progress_views.py
+++ b/journey/api/progress_views.py
@@ -48,6 +48,8 @@ class GameProgressViewSet(viewsets.ReadOnlyModelViewSet):
         queryset = Gameday.objects.filter(
             date__gte=start_date,
             date__lte=end_date,
+        ).exclude(
+            status=Gameday.STATUS_DRAFT,
         ).annotate(
             distance_from_today=Abs(
                 ExpressionWrapper(F('date') - today, output_field=DurationField())

--- a/journey/tests.py
+++ b/journey/tests.py
@@ -770,3 +770,26 @@ class GameProgressOrderingTests(APITestCase):
 
         returned_ids = [row['id'] for row in response.data['results']]
         self.assertEqual(returned_ids, [gd_minus2.id, gd_plus2.id])
+
+    def test_draft_gamedays_are_excluded(self):
+        """Draft gamedays must not appear on the progress dashboard."""
+        from datetime import time
+        from gamedays.models import Gameday
+
+        published = self._create_gameday(0)
+        draft = Gameday.objects.create(
+            name='Draft GD',
+            season=self.season,
+            league=self.league,
+            date=self.today,
+            start=time(10, 0),
+            author=self.author,
+            status=Gameday.STATUS_DRAFT,
+        )
+
+        response = self.client.get('/api/game-progress/')
+        self.assertEqual(response.status_code, 200)
+
+        returned_ids = [row['id'] for row in response.data['results']]
+        self.assertIn(published.id, returned_ids)
+        self.assertNotIn(draft.id, returned_ids)


### PR DESCRIPTION
## What
The `/gamedays/progress/` dashboard currently lists draft gamedays alongside published ones. Draft gamedays have no real schedule/results yet and should not appear in the public progress feed.

## Change
- `journey/api/progress_views.py`: exclude `status=Gameday.STATUS_DRAFT` from `GameProgressViewSet` queryset.
- `journey/tests.py`: regression test `test_draft_gamedays_are_excluded` (written first, failed before fix, passes after).

## Verification
- `GameProgressOrderingTests` and `GamedayProgressSerializerTests` pass. Remaining failures in `journey/tests.py` are pre-existing environment issues (tzdata `Europe/Berlin` missing), unchanged by this PR.