### PR TITLE
fix: require entry-owner authorization to delete gamelog entries

### DIFF
--- a/gamedays/api/game_views.py
+++ b/gamedays/api/game_views.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 from http import HTTPStatus
 
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import UpdateAPIView, RetrieveUpdateAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -107,18 +107,43 @@ class GameLogAPIView(APIView):
 
     def delete(self, request: Request, *args, **kwargs):
         game_id = kwargs.get("id")
+        sequence = request.data.get("sequence")
         try:
-            game_service = GameService(game_id)
-            gamelog = game_service.delete_gamelog(request.data.get("sequence"))
-            game_service.update_score(gamelog)
-            return Response(
-                json.loads(gamelog.as_json(), object_pairs_hook=OrderedDict),
-                status=HTTPStatus.OK,
-            )
+            game = Gameinfo.objects.get(pk=game_id)
         except Gameinfo.DoesNotExist:
             raise NotFound(
                 detail=f"Could not delete team logs ... gameId {game_id} not found"
             )
+        if not self._can_delete_log_entry(request.user, game, sequence):
+            raise PermissionDenied(
+                detail="You do not have permission to delete this game log entry."
+            )
+        game_service = GameService(game_id)
+        gamelog = game_service.delete_gamelog(sequence)
+        game_service.update_score(gamelog)
+        return Response(
+            json.loads(gamelog.as_json(), object_pairs_hook=OrderedDict),
+            status=HTTPStatus.OK,
+        )
+
+    @staticmethod
+    def _can_delete_log_entry(user, game: Gameinfo, sequence) -> bool:
+        """Whether the user may delete a log entry.
+
+        Allowed for staff, the gameday author, or the user who recorded the
+        entry (so on-site scorecard officials can still undo their own
+        mistakes while unrelated authenticated users cannot tamper with the
+        log).
+        """
+        if not user.is_authenticated:
+            return False
+        if user.is_staff:
+            return True
+        if game.gameday.author_id == user.pk:
+            return True
+        return TeamLog.objects.filter(
+            gameinfo=game, sequence=sequence, isDeleted=False, author=user
+        ).exists()
 
 
 class GameHalftimeAPIView(APIView):

--- a/gamedays/tests/api/test_game_views.py
+++ b/gamedays/tests/api/test_game_views.py
@@ -362,6 +362,59 @@ class TestGameLog(WebTest):
         assert json_response["home"]["score"] == 34
         assert json_response["home"]["firsthalf"]["entries"][1]["isDeleted"]
 
+    def test_delete_team_log_denied_for_anonymous(self):
+        gameinfo = DBSetup().create_teamlog_home_and_away()
+        response = self.app.delete_json(
+            reverse(API_GAMELOG, kwargs={"id": gameinfo.pk}),
+            {"sequence": 2},
+            expect_errors=True,
+        )
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert not TeamLog.objects.filter(
+            gameinfo=gameinfo, sequence=2, isDeleted=True
+        ).exists()
+
+    def test_delete_team_log_denied_for_unrelated_user(self):
+        gameinfo = DBSetup().create_teamlog_home_and_away()
+        unrelated = DBSetup().create_new_user(username="unrelated", is_staff=False)
+        response = self.app.delete_json(
+            reverse(API_GAMELOG, kwargs={"id": gameinfo.pk}),
+            {"sequence": 2},
+            headers=DBSetup().get_token_header(unrelated),
+            expect_errors=True,
+        )
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert not TeamLog.objects.filter(
+            gameinfo=gameinfo, sequence=2, isDeleted=True
+        ).exists()
+
+    def test_delete_team_log_allowed_for_entry_author(self):
+        DBSetup().g62_status_empty()
+        logger = DBSetup().create_new_user(username="logger", is_staff=False)
+        first_game = Gameinfo.objects.first()
+        self.app.post_json(
+            reverse(API_GAMELOG, kwargs={"id": first_game.pk}),
+            {
+                "team": "A1",
+                "gameId": first_game.pk,
+                "half": 1,
+                "event": [
+                    {"name": "Touchdown", "player": "19"},
+                    {"name": "1-Extra-Punkt", "player": "7"},
+                ],
+            },
+            headers=DBSetup().get_token_header(logger),
+        )
+        response = self.app.delete_json(
+            reverse(API_GAMELOG, kwargs={"id": first_game.pk}),
+            {"sequence": 1},
+            headers=DBSetup().get_token_header(logger),
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert TeamLog.objects.filter(
+            gameinfo=first_game, sequence=1, isDeleted=True
+        ).exists()
+
 
 class TestGameHalftime(WebTest):
     def test_halftime_submitted(self):


### PR DESCRIPTION
## Summary

`DELETE /api/gamelog/<id>` (`GameLogAPIView.delete` in `gamedays/api/game_views.py`) previously let **any authenticated user** delete game log entries for any game, with no ownership/authorization check. This PR closes that gap while preserving the scorecard workflow.

## Fix

Deletion is now limited to:

1. **Staff**, or
2. the **gameday author**, or
3. the **user who recorded the entry** (`TeamLog.author`).

`TeamLog.author` already tracks who created each entry, so the official who recorded a mistaken entry can still undo it via the scorecard, but unrelated authenticated users can no longer tamper with the log.

## Tests (TDD)

Added to `gamedays/tests/api/test_game_views.py::TestGameLog`:

- `test_delete_team_log_denied_for_anonymous` — anonymous DELETE → 401, entry not deleted
- `test_delete_team_log_denied_for_unrelated_user` — authenticated non-author/non-entry-owner → 403, entry not deleted
- `test_delete_team_log_allowed_for_entry_author` — the user who recorded the entry can delete it → 200

All 22 tests in `test_game_views.py` pass. `gamedays/tests/api` shows the same 18 pre-existing failures as the clean baseline (SQLite-test-env artifacts, unrelated to this change).

## Verification

```bash
DJANGO_SETTINGS_MODULE=league_manager.settings.test_sqlite pytest gamedays/tests/api/test_game_views.py
```

Closes #1746
