### PR TITLE
fix(passcheck): return 404 instead of 500 for unknown team roster

### DIFF
--- a/passcheck/tests/test_views.py
+++ b/passcheck/tests/test_views.py
@@ -39,6 +39,15 @@ class TestRosterView(WebTest):
         )
         assert response.status_code == HTTPStatus.OK
 
+    def test_unknown_team_returns_not_found(self):
+        user = DBSetup().create_new_user("some staff user", is_staff=True)
+        self.app.set_user(user)
+        response: DjangoWebtestResponse = self.app.get(
+            reverse(PASSCHECK_ROSTER_LIST, kwargs={"pk": 513}),
+            expect_errors=True,
+        )
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
 
 class TestPlayerlistDeleteView(WebTest):
     def test_display_team_roster(self):

--- a/passcheck/views.py
+++ b/passcheck/views.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.http import Http404
 from django.shortcuts import render, redirect, get_object_or_404
 from django.urls import reverse
 from django.views import View
@@ -33,11 +34,16 @@ class RosterView(View):
         passcheck_service = PasscheckService(user_permission=user_permission)
         from passcheck.urls import PASSCHECK_ROSTER_LIST_FOR_YEAR
 
+        try:
+            roster_context = passcheck_service.get_roster(team_id, year)
+        except ValueError:
+            raise Http404(f"Team {team_id} not found")
+
         context = {
             "season": year,
             "url_pattern": PASSCHECK_ROSTER_LIST_FOR_YEAR,
             "pk": team_id,
-            **passcheck_service.get_roster(team_id, year),
+            **roster_context,
         }
         return render(request, self.template_name, context)
 


### PR DESCRIPTION
## Summary
- `RosterView.get()` called `PasscheckService.get_roster()` without handling the `ValueError` it raises when the team id in the URL doesn't resolve to a `Team`, causing an unguarded 500 in production (observed for `/passcheck/team/513/list/`).
- Catches the `ValueError` and raises `Http404`, matching the existing precedent in `passcheck/api/views.py` where the sibling DRF endpoint already translates the same `ValueError` into a 404 `NotFound`.

## Test plan
- [x] Added `test_unknown_team_returns_not_found` reproducing the original 500 (RED), confirmed GREEN after the fix
- [x] Full `passcheck` backend suite passes (30/30)
- [x] `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)