### PR TITLE
chore: remove unused django-health-check app

### DIFF
--- a/league_manager/settings/base.py
+++ b/league_manager/settings/base.py
@@ -42,7 +42,6 @@ INSTALLED_APPS = [
     "gameday_designer",
     "matchreport",
     "journey",
-    "health_check",
 ]
 
 MIDDLEWARE = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "python-dotenv==1.2.2",
     "mysqlclient==2.2.8",
     "requests==2.34.2",
-    "django-health-check==4.4.4",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -326,19 +326,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-health-check"
-version = "4.4.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-    { name = "dnspython" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/46/d5/34eac70f0df0d67351692d77f46995ced3d55be09a842802e93d26abceaa/django_health_check-4.4.4.tar.gz", hash = "sha256:4d84f3b0e3015568023f111bc8b3ef5e5094556637e1e0f6202b2eca80c07b9b", size = 21923, upload-time = "2026-07-28T17:33:52.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/e8/3bc8e4045c026d3496040dceb06265da3d049de1ad4fa082f9414b62ae73/django_health_check-4.4.4-py3-none-any.whl", hash = "sha256:22a4807e06bb60ba98bb35c7c5a625db1a845fc373de3cad6e9d675939dbfe4d", size = 27027, upload-time = "2026-07-28T17:33:51.477Z" },
-]
-
-[[package]]
 name = "django-pandas"
 version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
@@ -386,15 +373,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/35/c96055e700fdff25da3a7b7756cfd1d4dc54f38b9bc6d6c5e19e3a0fdc20/djangorestframework-3.17.2.tar.gz", hash = "sha256:89ed713b6dc83e1539f214b7d10808ae19bb8511004beba886225da6d5c9dafa", size = 906683, upload-time = "2026-08-05T07:47:22.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/46/c14108e400b208c394325eb63fbae06c81341b6447fa1a6f9da718b17fe7/djangorestframework-3.17.2-py3-none-any.whl", hash = "sha256:cb0546a7415d5b46c04e0f4fe0a54b2109f4fdd5e83ca773c8c6183a6493d042", size = 899109, upload-time = "2026-08-05T07:47:20.853Z" },
-]
-
-[[package]]
-name = "dnspython"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -538,7 +516,6 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-crispy-forms" },
     { name = "django-formtools" },
-    { name = "django-health-check" },
     { name = "django-pandas" },
     { name = "django-rest-knox" },
     { name = "djangorestframework" },
@@ -581,7 +558,6 @@ requires-dist = [
     { name = "django-crispy-forms", specifier = "==2.7" },
     { name = "django-debug-toolbar", marker = "extra == 'test'", specifier = "==7.0.0" },
     { name = "django-formtools", specifier = "==2.7" },
-    { name = "django-health-check", specifier = "==4.4.4" },
     { name = "django-pandas", specifier = "==0.6.7" },
     { name = "django-rest-knox", specifier = "==5.1.0" },
     { name = "django-webtest", marker = "extra == 'test'", specifier = "==1.9.14" },


### PR DESCRIPTION
## Summary
- Removes the `health_check` app from `INSTALLED_APPS` and the `django-health-check` dependency — it's dead weight, since `/health/` was already switched to a plain sync view in `league_manager/urls.py` to avoid gunicorn worker deadlocks under the old async health-check view.
- Just having the app installed imports `health_check/checks.py`, whose `Mail` check reads `settings.EMAIL_BACKEND` as a dataclass field default at class-definition time, which triggers Django 6's `RemovedInDjango70Warning` on every process start (`django-health-check` 4.4.4, the latest release, hasn't migrated to the new `MAILERS` setting yet). Removing the unused app eliminates the warning instead of waiting on an upstream fix.
- No models/migrations were tied to the app, and nothing else in the codebase imports it — confirmed via full-repo grep.

## Test plan
- [x] `./container/spinup_test_db.sh --fresh` + `python manage.py migrate` — no `health_check` migrations existed, none lost
- [x] `pytest league_manager/tests/test_health_check.py -W error::DeprecationWarning` — passes, warning no longer raised
- [x] Full suite: `pytest -n auto` — 912 passed, 1 xfailed (2 pre-existing, unrelated `test_db_guard.py` failures confirmed present on `master` before this change too — a separate middleware-ordering bug, out of scope here)
- [x] `black --check` on changed files — clean (repo-wide black has an unrelated pre-existing Python 3.14/3.15 target mismatch, confirmed present on `master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)