### PR TITLE
feat(gamedays): add StageCategory enum and legacy stage-name heuristic

### DIFF
--- a/gamedays/service/stage_category.py
+++ b/gamedays/service/stage_category.py
@@ -1,0 +1,34 @@
+from django.db import models
+
+
+class StageCategory(models.TextChoices):
+    """
+    Mirrors the Designer's StageCategory type
+    (gameday_designer/src/types/flowchart.ts:160). A stage's *display name*
+    (e.g. "Liga", "Vorrunde", "Preliminary") is free text chosen by whoever
+    builds the schedule; this is the separate, structured signal for
+    "does this stage's games count toward the round-robin standings table".
+    """
+
+    PRELIMINARY = "preliminary", "Preliminary"
+    FINAL = "final", "Final"
+    PLACEMENT = "placement", "Placement"
+    CUSTOM = "custom", "Custom"
+
+
+_LEGACY_STAGE_NAME_TO_CATEGORY = {
+    "Vorrunde": StageCategory.PRELIMINARY,
+    "Hauptrunde": StageCategory.PRELIMINARY,
+    "Finalrunde": StageCategory.FINAL,
+    "Zwischenrunde": StageCategory.PLACEMENT,
+}
+
+
+def derive_legacy_stage_category(stage_name: str) -> str:
+    """
+    Best-effort category for gamedays created outside the Designer, where no
+    structured category is available — only a free-text stage name. Mirrors
+    the fixed vocabulary used by gamedays/management/schedules/*.json and the
+    manual gameinfo-entry form (gamedays/forms.py).
+    """
+    return _LEGACY_STAGE_NAME_TO_CATEGORY.get(stage_name, StageCategory.CUSTOM)

--- a/gamedays/tests/service/test_stage_category.py
+++ b/gamedays/tests/service/test_stage_category.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase
+
+from gamedays.service.stage_category import StageCategory, derive_legacy_stage_category
+
+
+class TestDeriveLegacyStageCategory(SimpleTestCase):
+    def test_vorrunde_is_preliminary(self):
+        assert derive_legacy_stage_category("Vorrunde") == StageCategory.PRELIMINARY
+
+    def test_hauptrunde_is_preliminary(self):
+        assert derive_legacy_stage_category("Hauptrunde") == StageCategory.PRELIMINARY
+
+    def test_finalrunde_is_final(self):
+        assert derive_legacy_stage_category("Finalrunde") == StageCategory.FINAL
+
+    def test_zwischenrunde_is_placement(self):
+        assert derive_legacy_stage_category("Zwischenrunde") == StageCategory.PLACEMENT
+
+    def test_unknown_stage_name_is_custom(self):
+        assert derive_legacy_stage_category("Liga") == StageCategory.CUSTOM
+        assert derive_legacy_stage_category("FF BL") == StageCategory.CUSTOM
+        assert derive_legacy_stage_category("") == StageCategory.CUSTOM


### PR DESCRIPTION
Task 1/7 of the gameday stage-category stack. See docs/superpowers/plans/2026-08-06-gameday-stage-category.md for the full plan. This PR: adds gamedays/service/stage_category.py — a StageCategory enum and derive_legacy_stage_category() heuristic, the foundation the rest of the stack builds on. No behavior change yet (unused by any other code in this PR).