### PR TITLE
feat(gamedays): backfill stage_category from designer state and legacy heuristic

### DIFF
--- a/gamedays/migrations/0041_backfill_stage_category.py
+++ b/gamedays/migrations/0041_backfill_stage_category.py
@@ -52,7 +52,12 @@ def backfill_stage_category(apps_module, schema_editor):
 
 
 def reverse_backfill_stage_category(apps_module, schema_editor):
-    Gameinfo = apps_module.get_model("gamedays", "Gameinfo")
+    if apps_module is not None:
+        Gameinfo = apps_module.get_model("gamedays", "Gameinfo")
+    else:
+        # Allows direct unit testing against the current models (see
+        # gamedays/tests/migrations/test_backfill_stage_category.py).
+        from gamedays.models import Gameinfo
     Gameinfo.objects.update(stage_category="")
 
 

--- a/gamedays/migrations/0041_backfill_stage_category.py
+++ b/gamedays/migrations/0041_backfill_stage_category.py
@@ -1,0 +1,69 @@
+from django.db import migrations
+
+_LEGACY_STAGE_NAME_TO_CATEGORY = {
+    "Vorrunde": "preliminary",
+    "Hauptrunde": "preliminary",
+    "Finalrunde": "final",
+    "Zwischenrunde": "placement",
+}
+
+
+def _category_map_from_designer_state(state_data) -> dict:
+    nodes = (state_data or {}).get("nodes", [])
+    return {
+        node["data"]["name"]: node["data"].get("category", "preliminary")
+        for node in nodes
+        if node.get("type") == "stage" and node.get("data", {}).get("name")
+    }
+
+
+def backfill_stage_category(apps_module, schema_editor):
+    if apps_module is not None:
+        Gameinfo = apps_module.get_model("gamedays", "Gameinfo")
+        GamedayDesignerState = apps_module.get_model("gamedays", "GamedayDesignerState")
+    else:
+        # Allows direct unit testing against the current models (see
+        # gamedays/tests/migrations/test_backfill_stage_category.py).
+        from gamedays.models import Gameinfo, GamedayDesignerState
+
+    for state in GamedayDesignerState.objects.all():
+        name_to_category = _category_map_from_designer_state(state.state_data)
+        if not name_to_category:
+            continue
+        rows = list(
+            Gameinfo.objects.filter(gameday_id=state.gameday_id, stage_category="")
+        )
+        if not rows:
+            continue
+        to_update = []
+        for row in rows:
+            category = name_to_category.get(row.stage)
+            if category:
+                row.stage_category = category
+                to_update.append(row)
+        if to_update:
+            Gameinfo.objects.bulk_update(to_update, ["stage_category"])
+
+    remaining = list(Gameinfo.objects.filter(stage_category=""))
+    for row in remaining:
+        row.stage_category = _LEGACY_STAGE_NAME_TO_CATEGORY.get(row.stage, "custom")
+    if remaining:
+        Gameinfo.objects.bulk_update(remaining, ["stage_category"], batch_size=500)
+
+
+def reverse_backfill_stage_category(apps_module, schema_editor):
+    Gameinfo = apps_module.get_model("gamedays", "Gameinfo")
+    Gameinfo.objects.update(stage_category="")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gamedays", "0040_gameinfo_stage_category"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_stage_category,
+            reverse_code=reverse_backfill_stage_category,
+        ),
+    ]

--- a/gamedays/migrations/0041_backfill_stage_category.py
+++ b/gamedays/migrations/0041_backfill_stage_category.py
@@ -11,9 +11,11 @@ _LEGACY_STAGE_NAME_TO_CATEGORY = {
 def _category_map_from_designer_state(state_data) -> dict:
     nodes = (state_data or {}).get("nodes", [])
     return {
-        node["data"]["name"]: node["data"].get("category", "preliminary")
+        node["data"]["name"]: node["data"]["category"]
         for node in nodes
-        if node.get("type") == "stage" and node.get("data", {}).get("name")
+        if node.get("type") == "stage"
+        and (node.get("data") or {}).get("name")
+        and (node.get("data") or {}).get("category")
     }
 
 

--- a/gamedays/tests/migrations/test_backfill_stage_category.py
+++ b/gamedays/tests/migrations/test_backfill_stage_category.py
@@ -96,3 +96,57 @@ class TestBackfillStageCategory(TestCase):
         gi_heuristic.refresh_from_db()
         assert gi_designer.stage_category == ""
         assert gi_heuristic.stage_category == ""
+
+    def test_falls_through_to_heuristic_when_designer_node_has_no_category_key(self):
+        # Pre-v2 designer states have stage nodes with a "name" but no "category"
+        # key at all — this must NOT default to "preliminary"; it must fall
+        # through to the legacy name-based heuristic pass instead.
+        gameday = DBSetup().create_empty_gameday()
+        gi = GameinfoFactory(gameday=gameday, stage="Finalrunde")
+        Gameinfo.objects.filter(pk=gi.pk).update(stage_category="")
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    {"type": "stage", "data": {"name": "Finalrunde"}},
+                ]
+            },
+        )
+
+        _migration.backfill_stage_category(apps_module=None, schema_editor=None)
+
+        gi.refresh_from_db()
+        assert gi.stage_category == "final"
+
+    def test_tolerates_stage_node_with_null_data(self):
+        # A stage node can have a literal "data": None (key present, value null).
+        # This must not raise and must not block backfilling other rows for the
+        # same gameday.
+        gameday = DBSetup().create_empty_gameday()
+        gi_null_data = GameinfoFactory(gameday=gameday, stage="Finalrunde")
+        gi_well_formed = GameinfoFactory(gameday=gameday, stage="Liga")
+        Gameinfo.objects.filter(pk__in=[gi_null_data.pk, gi_well_formed.pk]).update(
+            stage_category=""
+        )
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    {"type": "stage", "data": None},
+                    {
+                        "type": "stage",
+                        "data": {"name": "Liga", "category": "preliminary"},
+                    },
+                ]
+            },
+        )
+
+        _migration.backfill_stage_category(apps_module=None, schema_editor=None)
+
+        gi_null_data.refresh_from_db()
+        gi_well_formed.refresh_from_db()
+        # "Finalrunde" had no usable designer-state entry (its node's data was
+        # None), so it falls through to the legacy heuristic.
+        assert gi_null_data.stage_category == "final"
+        # "Liga" was resolved from the well-formed sibling node.
+        assert gi_well_formed.stage_category == "preliminary"

--- a/gamedays/tests/migrations/test_backfill_stage_category.py
+++ b/gamedays/tests/migrations/test_backfill_stage_category.py
@@ -68,3 +68,31 @@ class TestBackfillStageCategory(TestCase):
 
         gi.refresh_from_db()
         assert gi.stage_category == "custom"
+
+    def test_reverse_resets_stage_category_to_blank(self):
+        gameday = DBSetup().create_empty_gameday()
+        gi_designer = GameinfoFactory(gameday=gameday, stage="Liga")
+        gi_heuristic = GameinfoFactory(gameday=gameday, stage="Hauptrunde")
+        Gameinfo.objects.filter(
+            pk__in=[gi_designer.pk, gi_heuristic.pk]
+        ).update(stage_category="")
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    {"type": "stage", "data": {"name": "Liga", "category": "preliminary"}}
+                ]
+            },
+        )
+        _migration.backfill_stage_category(apps_module=None, schema_editor=None)
+        gi_designer.refresh_from_db()
+        gi_heuristic.refresh_from_db()
+        assert gi_designer.stage_category == "preliminary"
+        assert gi_heuristic.stage_category == "preliminary"
+
+        _migration.reverse_backfill_stage_category(apps_module=None, schema_editor=None)
+
+        gi_designer.refresh_from_db()
+        gi_heuristic.refresh_from_db()
+        assert gi_designer.stage_category == ""
+        assert gi_heuristic.stage_category == ""

--- a/gamedays/tests/migrations/test_backfill_stage_category.py
+++ b/gamedays/tests/migrations/test_backfill_stage_category.py
@@ -1,0 +1,70 @@
+import importlib
+
+from django.test import TestCase
+
+from gamedays.models import Gameinfo, GamedayDesignerState
+from gamedays.tests.setup_factories.db_setup import DBSetup
+from gamedays.tests.setup_factories.factories import GameinfoFactory
+
+_migration = importlib.import_module("gamedays.migrations.0041_backfill_stage_category")
+
+
+class TestBackfillStageCategory(TestCase):
+    def test_backfills_from_designer_state_when_present(self):
+        gameday = DBSetup().create_empty_gameday()
+        gi_preliminary = GameinfoFactory(gameday=gameday, stage="Liga")
+        gi_final = GameinfoFactory(gameday=gameday, stage="Playoffs")
+        # bypass the Task 2 save() fallback to simulate pre-migration data
+        Gameinfo.objects.filter(pk__in=[gi_preliminary.pk, gi_final.pk]).update(
+            stage_category=""
+        )
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    {
+                        "type": "stage",
+                        "data": {"name": "Liga", "category": "preliminary"},
+                    },
+                    {
+                        "type": "stage",
+                        "data": {"name": "Playoffs", "category": "final"},
+                    },
+                ]
+            },
+        )
+
+        _migration.backfill_stage_category(apps_module=None, schema_editor=None)
+
+        gi_preliminary.refresh_from_db()
+        gi_final.refresh_from_db()
+        assert gi_preliminary.stage_category == "preliminary"
+        assert gi_final.stage_category == "final"
+
+    def test_backfills_from_legacy_heuristic_when_no_designer_state(self):
+        gameday = DBSetup().create_empty_gameday()
+        gi = GameinfoFactory(gameday=gameday, stage="Hauptrunde")
+        Gameinfo.objects.filter(pk=gi.pk).update(stage_category="")
+
+        _migration.backfill_stage_category(apps_module=None, schema_editor=None)
+
+        gi.refresh_from_db()
+        assert gi.stage_category == "preliminary"
+
+    def test_leaves_already_populated_rows_untouched(self):
+        gameday = DBSetup().create_empty_gameday()
+        gi = GameinfoFactory(gameday=gameday, stage="Liga")
+        Gameinfo.objects.filter(pk=gi.pk).update(stage_category="custom")
+        GamedayDesignerState.objects.create(
+            gameday=gameday,
+            state_data={
+                "nodes": [
+                    {"type": "stage", "data": {"name": "Liga", "category": "preliminary"}}
+                ]
+            },
+        )
+
+        _migration.backfill_stage_category(apps_module=None, schema_editor=None)
+
+        gi.refresh_from_db()
+        assert gi.stage_category == "custom"


### PR DESCRIPTION
Task 3/7 of the gameday stage-category stack (stacked on #1772). See docs/superpowers/plans/2026-08-06-gameday-stage-category.md.

This PR: adds a data migration that backfills Gameinfo.stage_category for existing rows — recovering the organizer's real category choice from GamedayDesignerState.state_data where a gameday was published via the Designer, and using the legacy name heuristic (same lookup as derive_legacy_stage_category) everywhere else.

Deliberately inlines its own copy of the category lookup rather than importing gamedays.service.stage_category, per this repo's existing data-migration convention (see 0031_migrate_gameinfo_status_completed.py) — migrations should not depend on app code that can change after the migration is written.