### PR TITLE
feat(gamedays): persist designer stage category when publishing canvas

### DIFF
--- a/gamedays/service/canvas_publish_service.py
+++ b/gamedays/service/canvas_publish_service.py
@@ -1,4 +1,5 @@
 from gamedays.models import Gameday, Gameinfo, Gameresult, GamedayDesignerState, Team
+from gamedays.service.stage_category import StageCategory
 
 
 OFFICIALS_PLACEHOLDER = "N/A"
@@ -44,6 +45,9 @@ class CanvasPublishService:
 
             field_num = field_node.get("data", {}).get("order", 0) + 1
             stage_name = stage_node.get("data", {}).get("name", "")
+            stage_category = stage_node.get("data", {}).get(
+                "category", StageCategory.PRELIMINARY
+            )
             standing = data.get("standing", "")
             start_time = data.get("startTime") or str(self.gameday.start)
 
@@ -56,6 +60,7 @@ class CanvasPublishService:
                 scheduled=start_time,
                 field=field_num,
                 stage=stage_name,
+                stage_category=stage_category,
                 standing=standing,
                 officials=officials,
                 status=Gameinfo.STATUS_PUBLISHED,

--- a/gamedays/tests/service/test_canvas_publish_service.py
+++ b/gamedays/tests/service/test_canvas_publish_service.py
@@ -1,0 +1,79 @@
+from django.test import TestCase
+
+from gamedays.models import Gameinfo, GamedayDesignerState
+from gamedays.service.canvas_publish_service import CanvasPublishService
+from gamedays.service.stage_category import StageCategory
+from gamedays.tests.setup_factories.db_setup import DBSetup
+
+
+def _state_data_with_one_game(stage_category="preliminary"):
+    return {
+        "nodes": [
+            {
+                "id": "field-1",
+                "type": "field",
+                "data": {"type": "field", "name": "Feld 1", "order": 0},
+            },
+            {
+                "id": "stage-1",
+                "type": "stage",
+                "parentId": "field-1",
+                "data": {
+                    "type": "stage",
+                    "name": "Liga",
+                    "category": stage_category,
+                    "stageType": "STANDARD",
+                },
+            },
+            {
+                "id": "game-1",
+                "type": "game",
+                "parentId": "stage-1",
+                "data": {
+                    "type": "game",
+                    "standing": "Tabelle",
+                    "startTime": "10:00",
+                    "homeTeamId": None,
+                    "awayTeamId": None,
+                    "official": None,
+                },
+            },
+        ],
+        "globalTeams": [],
+    }
+
+
+class TestCanvasPublishServiceStageCategory(TestCase):
+    def test_apply_persists_preliminary_category_from_stage_node(self):
+        gameday = DBSetup().create_empty_gameday()
+        GamedayDesignerState.objects.create(
+            gameday=gameday, state_data=_state_data_with_one_game("preliminary")
+        )
+
+        CanvasPublishService(gameday).apply()
+
+        gi = Gameinfo.objects.get(gameday=gameday)
+        assert gi.stage == "Liga"
+        assert gi.stage_category == StageCategory.PRELIMINARY
+
+    def test_apply_persists_final_category_from_stage_node(self):
+        gameday = DBSetup().create_empty_gameday()
+        GamedayDesignerState.objects.create(
+            gameday=gameday, state_data=_state_data_with_one_game("final")
+        )
+
+        CanvasPublishService(gameday).apply()
+
+        gi = Gameinfo.objects.get(gameday=gameday)
+        assert gi.stage_category == StageCategory.FINAL
+
+    def test_apply_defaults_to_preliminary_when_stage_node_has_no_category(self):
+        state_data = _state_data_with_one_game("preliminary")
+        del state_data["nodes"][1]["data"]["category"]
+        gameday = DBSetup().create_empty_gameday()
+        GamedayDesignerState.objects.create(gameday=gameday, state_data=state_data)
+
+        CanvasPublishService(gameday).apply()
+
+        gi = Gameinfo.objects.get(gameday=gameday)
+        assert gi.stage_category == StageCategory.PRELIMINARY


### PR DESCRIPTION
Task 4/7 of the gameday stage-category stack (stacked on #1773). See docs/superpowers/plans/2026-08-06-gameday-stage-category.md. This PR: CanvasPublishService.apply() now reads the stage node's category field from the designer canvas JSON and writes it directly to Gameinfo.stage_category, instead of relying on the Task-2 auto-derive fallback (which can only guess from the free-text stage name and has no way to see the organizer's actual category choice). Also adds the first test coverage this service has ever had.