### PR TITLE
feat(gamedays): set stage_category explicitly in legacy schedule creation

### DIFF
--- a/gamedays/management/schedule_manager.py
+++ b/gamedays/management/schedule_manager.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Union, List, Optional
 
 from gamedays.models import Team, Gameday, Gameinfo, Gameresult
+from gamedays.service.stage_category import derive_legacy_stage_category
 from league_table.models import LeagueGroup
 
 
@@ -201,6 +202,7 @@ class ScheduleCreator:
         gameinfo.gameday = self.gameday
         gameinfo.scheduled = scheduled
         gameinfo.stage = game.stage
+        gameinfo.stage_category = derive_legacy_stage_category(game.stage)
         gameinfo.field = field
         gameinfo.standing = game.standing
         gameinfo.league_group = game.league_group

--- a/gamedays/tests/management/test_schedule_manager.py
+++ b/gamedays/tests/management/test_schedule_manager.py
@@ -128,6 +128,42 @@ class TestScheduleCreator(TestCase):
         assert Gameresult.objects.filter(gameinfo=gameinfo).count() == 2
         assert Gameresult.objects.all().count() == 12
 
+    def test_schedule_created_sets_preliminary_stage_category_for_hauptrunde(self):
+        gameday = DBSetup().create_empty_gameday()
+        DBSetup().create_playoff_placeholder_teams()
+        group_A = DBSetup().create_teams("A", 4)
+        sc = ScheduleCreator(
+            gameday=Gameday.objects.get(pk=gameday.pk),
+            schedule=Schedule("4_1", [GroupSchedule("Group 1", None, group_A)]),
+        )
+        sc.create()
+        gameinfo_set = Gameinfo.objects.filter(gameday_id=gameday.pk)
+        assert gameinfo_set.count() == 6
+        for gi in gameinfo_set:
+            assert gi.stage == "Hauptrunde"
+            assert gi.stage_category == "preliminary"
+
+    def test_schedule_created_sets_final_stage_category_for_finalrunde(self):
+        gameday = DBSetup().create_empty_gameday()
+        DBSetup().create_playoff_placeholder_teams()
+        group_A = DBSetup().create_teams("A", 3)
+        group_B = DBSetup().create_teams("B", 3)
+        groups = [
+            GroupSchedule(name="Gruppe 1", league_group=None, teams=group_A),
+            GroupSchedule(name="Gruppe 2", league_group=None, teams=group_B),
+        ]
+        sc = ScheduleCreator(
+            gameday=Gameday.objects.get(pk=gameday.pk),
+            schedule=Schedule("6_2", groups),
+        )
+        sc.create()
+        finalrunde_games = Gameinfo.objects.filter(
+            gameday_id=gameday.pk, stage="Finalrunde"
+        )
+        assert finalrunde_games.exists()
+        for gi in finalrunde_games:
+            assert gi.stage_category == "final"
+
     def test_schedule_created_for_4_teams_with_league_group(self):
         gameday = DBSetup().create_empty_gameday()
         DBSetup().create_playoff_placeholder_teams()


### PR DESCRIPTION
Task 5/7 of the gameday stage-category stack (stacked on #1774). See docs/superpowers/plans/2026-08-06-gameday-stage-category.md. This PR: ScheduleCreator (the legacy JSON-template schedule-creation path, e.g. formats like `6_2`/`4_1`) now sets Gameinfo.stage_category explicitly via derive_legacy_stage_category(), instead of relying implicitly on Gameinfo.save()'s Task-2 fallback. Both producers (Designer via #1774, legacy schedule creation via this PR) now populate the field explicitly; the save() fallback remains as a safety net for any other/future write path.