### PR TITLE
test(gamedays): end-to-end regression test for gameday details qualify-table 500

### DIFF
--- a/gamedays/tests/api/test_views.py
+++ b/gamedays/tests/api/test_views.py
@@ -140,6 +140,34 @@ class TestGamedaySchedule(WebTest):
         assert response.status_code == HTTPStatus.OK
         assert response.json == []
 
+    @patch("league_table.service.datatypes.LeagueConfigRuleset.from_ruleset")
+    def test_gameday_details_qualify_table_for_designer_stage_name_returns_200(
+        self, mock_get_league_config_ruleset
+    ):
+        """
+        Regression test for the prod incident where /api/gameday/<id>/details?get=qualify
+        500'd with KeyError: "['win_points'] not in index" for any gameday
+        whose stage name wasn't literally "Vorrunde" or "Hauptrunde" (e.g.
+        Designer-published gamedays named "Liga").
+        """
+        mock_get_league_config_ruleset.return_value = LEAGUE_TABLE_TEST_RULESET
+        gameday = DBSetup().create_empty_gameday()
+        LeagueSeasonConfigFactory(league=gameday.league, season=gameday.season)
+        DBSetup().create_group(
+            gameday=gameday,
+            name="A",
+            stage="Liga",
+            standing="Tabelle",
+            status="beendet",
+            number_teams=3,
+        )
+
+        response = self.app.get(
+            reverse("api-gameday-schedule", kwargs={"pk": gameday.pk}) + "?get=qualify"
+        )
+
+        assert response.status_code == HTTPStatus.OK
+
 
 class TestGamesToWhistleAPIView(WebTest):
     def test_get_games_to_whistle_for_specific_team(self):


### PR DESCRIPTION
Task 7/7 (final) of the gameday stage-category stack (stacked on #1776). See docs/superpowers/plans/2026-08-06-gameday-stage-category.md.

This PR: adds an end-to-end regression test through the real GamedayScheduleView/DRF layer, proving /api/gameday/<id>/details?get=qualify returns 200 (not 500) for a gameday with a non-legacy stage name ("Liga"), through the real production path with no test-only shortcuts — Gameinfo creation, Gameinfo.save()'s auto-derive fallback, GamedayModelWrapper's stage_category-based filtering (fixed in #1776), through to the API response.

Note on what this proves: "Liga" resolves to StageCategory.CUSTOM via the legacy heuristic (not PRELIMINARY, since it's not one of the four recognized legacy stage names), so the qualify table returned is empty. This test proves the win_points KeyError is gone for a non-legacy stage name via the real production path — not that a populated table renders correctly. Task 6's unit tests already cover populated-table correctness with an explicit stage_category=preliminary override.

This is the top of the stack — all 7 PRs together are ready for review.

Test results:
- New test passes: test_gameday_details_qualify_table_for_designer_stage_name_returns_200
- Full gamedays suite: 403 passed, 1 xfailed (baseline 402, +1 new test)
