### PR TITLE
fix(gameday_designer): resolve winner/loser official refs to readable labels

### DIFF
--- a/gameday_designer/src/components/list/GameTable.tsx
+++ b/gameday_designer/src/components/list/GameTable.tsx
@@ -389,23 +389,44 @@ const GameTable: React.FC<GameTableProps> = memo(({
     }
   }, [onRemoveEdgeFromSlot, onAddGameToGameEdge, onAddStageToGameEdge, onAssignTeam]);
 
+  const resolveOfficialReference = useCallback(
+    (value: string): TeamReference | undefined => {
+      if (value.startsWith('winner:') || value.startsWith('loser:')) {
+        const [type, sourceGameId] = value.split(':');
+        const sourceGame = allNodes.find(
+          (n) => isGameNode(n) && n.id === sourceGameId
+        ) as GameNode | undefined;
+        if (sourceGame) {
+          return { type: type as 'winner' | 'loser', matchName: sourceGame.data.standing };
+        }
+        return undefined;
+      }
+      if (value.startsWith('rank:')) {
+        const parts = value.split(':');
+        const stageId = parts[2];
+        const place = parseInt(parts[parts.length - 1], 10);
+        const stageNode = allNodes.find((n) => isStageNode(n) && n.id === stageId) as StageNode | undefined;
+        const stageName = stageNode?.data.name || '';
+        if (parts[1] === 'group') {
+          const groupName = parts.slice(3, -1).join(':');
+          return { type: 'groupRank', place, groupName, stageId, stageName } as TeamReference;
+        }
+        return { type: 'rank', place, stageId, stageName } as TeamReference;
+      }
+      return { type: 'static', name: value };
+    },
+    [allNodes]
+  );
+
   const handleOfficialChange = useCallback(
     (gameId: string, value: string) => {
       if (!value) {
         onUpdate(gameId, { official: undefined });
         return;
       }
-      
-      // If the value looks like a dynamic reference (winner:..., loser:..., rank:...)
-      // we should ideally parse it back to a TeamReference object.
-      // But for simplicity and backward compatibility, we can wrap it in a static ref
-      // or handle it as a string if we've updated the types.
-      // Given the backend changes, wrapping in a static reference is safe.
-      onUpdate(gameId, { 
-        official: { type: 'static', name: value } as TeamReference 
-      });
+      onUpdate(gameId, { official: resolveOfficialReference(value) });
     },
-    [onUpdate]
+    [onUpdate, resolveOfficialReference]
   );
 
 
@@ -536,6 +557,13 @@ const GameTable: React.FC<GameTableProps> = memo(({
     } else if (official) {
       if (official.type === 'static') {
         currentValue = official.name;
+        // Backward compatibility: older canvases stored a raw
+        // `winner:<gameId>`/`loser:<gameId>` string as a static official.
+        if (currentValue.startsWith('winner:') || currentValue.startsWith('loser:')) {
+          const [type, sourceGameId] = currentValue.split(':');
+          const sourceGame = allNodes.find((n) => isGameNode(n) && n.id === sourceGameId) as GameNode | undefined;
+          if (sourceGame) currentValue = `${type}:${sourceGame.id}`;
+        }
       } else if (official.type === 'winner' || official.type === 'loser') {
         // Officials aren't wired into game-to-game edges like home/away teams,
         // so resolve the source game by matching `standing`, same as bracketResolution.ts
@@ -544,6 +572,10 @@ const GameTable: React.FC<GameTableProps> = memo(({
         if (sourceGame) {
           currentValue = `${official.type}:${sourceGame.id}`;
         }
+      } else if (official.type === 'rank') {
+        currentValue = `rank:${official.stageId}:${official.place}`;
+      } else if (official.type === 'groupRank') {
+        currentValue = `rank:group:${official.stageId}:${official.groupName}:${official.place}`;
       }
     }
 

--- a/gameday_designer/src/components/list/GameTable.tsx
+++ b/gameday_designer/src/components/list/GameTable.tsx
@@ -37,6 +37,8 @@ interface TeamOption {
   isDisabled?: boolean;
   isWinner?: boolean;
   winnerLabel?: string;
+  /** Resolved TeamReference for dynamic options (winner/loser/rank/etc.) */
+  reference?: TeamReference;
 }
 
 // Custom Option component with colored dot for teams and stage headers
@@ -389,44 +391,15 @@ const GameTable: React.FC<GameTableProps> = memo(({
     }
   }, [onRemoveEdgeFromSlot, onAddGameToGameEdge, onAddStageToGameEdge, onAssignTeam]);
 
-  const resolveOfficialReference = useCallback(
-    (value: string): TeamReference | undefined => {
-      if (value.startsWith('winner:') || value.startsWith('loser:')) {
-        const [type, sourceGameId] = value.split(':');
-        const sourceGame = allNodes.find(
-          (n) => isGameNode(n) && n.id === sourceGameId
-        ) as GameNode | undefined;
-        if (sourceGame) {
-          return { type: type as 'winner' | 'loser', matchName: sourceGame.data.standing };
-        }
-        return undefined;
-      }
-      if (value.startsWith('rank:')) {
-        const parts = value.split(':');
-        const stageId = parts[2];
-        const place = parseInt(parts[parts.length - 1], 10);
-        const stageNode = allNodes.find((n) => isStageNode(n) && n.id === stageId) as StageNode | undefined;
-        const stageName = stageNode?.data.name || '';
-        if (parts[1] === 'group') {
-          const groupName = parts.slice(3, -1).join(':');
-          return { type: 'groupRank', place, groupName, stageId, stageName } as TeamReference;
-        }
-        return { type: 'rank', place, stageId, stageName } as TeamReference;
-      }
-      return { type: 'static', name: value };
-    },
-    [allNodes]
-  );
-
   const handleOfficialChange = useCallback(
-    (gameId: string, value: string) => {
-      if (!value) {
+    (gameId: string, option: TeamOption) => {
+      if (!option.value) {
         onUpdate(gameId, { official: undefined });
         return;
       }
-      onUpdate(gameId, { official: resolveOfficialReference(value) });
+      onUpdate(gameId, { official: option.reference ?? { type: 'static', name: option.value } });
     },
-    [onUpdate, resolveOfficialReference]
+    [onUpdate]
   );
 
 
@@ -462,7 +435,8 @@ const GameTable: React.FC<GameTableProps> = memo(({
         options.push({
           value: `rank:${stage.id}:${place}`,
           label: `🏆 ${t('ui:message.placeFrom', { place, stage: stage.data.name })}`,
-          isTeam: false
+          isTeam: false,
+          reference: { type: 'rank', place, stageId: stage.id, stageName: stage.data.name },
         });
       });
 
@@ -475,7 +449,8 @@ const GameTable: React.FC<GameTableProps> = memo(({
           options.push({
             value: `rank:group:${stage.id}:${groupName}:${place}`,
             label: `🎖️ ${t('ui:message.placeInGroup', { place, group: groupName, stage: stage.data.name })}`,
-            isTeam: false
+            isTeam: false,
+            reference: { type: 'groupRank', place, groupName, stageId: stage.id, stageName: stage.data.name },
           });
         });
       });
@@ -598,8 +573,8 @@ const GameTable: React.FC<GameTableProps> = memo(({
       const stageNode = allNodes.find(n => n.id === stageId);
       options.push({ value: `stage-header-${stageId}`, label: stageData.name, color: (stageNode?.data as import('../../types/flowchart').StageNodeData)?.color || '#0d6efd', isStageHeader: true, isDisabled: true });
       stageData.games.forEach((sourceGame) => {
-        options.push({ value: `winner:${sourceGame.id}`, label: `⚡ ${t('ui:message.winnerOf', { match: sourceGame.data.standing })} (${stageData.name})`, isTeam: false });
-        options.push({ value: `loser:${sourceGame.id}`, label: `💔 ${t('ui:message.loserOf', { match: sourceGame.data.standing })} (${stageData.name})`, isTeam: false });
+        options.push({ value: `winner:${sourceGame.id}`, label: `⚡ ${t('ui:message.winnerOf', { match: sourceGame.data.standing })} (${stageData.name})`, isTeam: false, reference: { type: 'winner', matchName: sourceGame.data.standing } });
+        options.push({ value: `loser:${sourceGame.id}`, label: `💔 ${t('ui:message.loserOf', { match: sourceGame.data.standing })} (${stageData.name})`, isTeam: false, reference: { type: 'loser', matchName: sourceGame.data.standing } });
       });
     });
 
@@ -616,7 +591,7 @@ const GameTable: React.FC<GameTableProps> = memo(({
           classNamePrefix="official-select"
           value={options.find(opt => opt.value === currentValue) || null}
           options={options}
-          onChange={(newValue) => newValue && handleOfficialChange(game.id, newValue.value)}
+          onChange={(newValue) => newValue && handleOfficialChange(game.id, newValue)}
           components={{ Option: CustomOption, SingleValue: CustomSingleValue }}
           isOptionDisabled={(option) => option.isDisabled || false}
           menuPortalTarget={document.body}

--- a/gameday_designer/src/components/list/GameTable.tsx
+++ b/gameday_designer/src/components/list/GameTable.tsx
@@ -532,13 +532,6 @@ const GameTable: React.FC<GameTableProps> = memo(({
     } else if (official) {
       if (official.type === 'static') {
         currentValue = official.name;
-        // Backward compatibility: older canvases stored a raw
-        // `winner:<gameId>`/`loser:<gameId>` string as a static official.
-        if (currentValue.startsWith('winner:') || currentValue.startsWith('loser:')) {
-          const [type, sourceGameId] = currentValue.split(':');
-          const sourceGame = allNodes.find((n) => isGameNode(n) && n.id === sourceGameId) as GameNode | undefined;
-          if (sourceGame) currentValue = `${type}:${sourceGame.id}`;
-        }
       } else if (official.type === 'winner' || official.type === 'loser') {
         // Officials aren't wired into game-to-game edges like home/away teams,
         // so resolve the source game by matching `standing`, same as bracketResolution.ts

--- a/gameday_designer/src/components/list/__tests__/GameTable.test.tsx
+++ b/gameday_designer/src/components/list/__tests__/GameTable.test.tsx
@@ -219,6 +219,30 @@ describe('GameTable', () => {
       const table = screen.getByRole('table');
       expect(table).toBeInTheDocument();
     });
+
+    it('stores a winner-of-game reference as a typed reference, not a raw string', async () => {
+      const user = userEvent.setup();
+      const { container } = renderTable();
+      // game1 (standing "Quali 1") is upstream of game2 and therefore eligible
+      await user.click(container.querySelector('.official-select__control')!);
+      const option = await screen.findByText(/Winner of Quali 1/i);
+      await user.click(option);
+      expect(mockOnUpdate).toHaveBeenCalledWith('game-2', {
+        official: { type: 'winner', matchName: 'Quali 1' },
+      });
+    });
+
+    it('renders an existing winner-of-game official reference as a readable label', async () => {
+      const gameWithWinnerOfficial = {
+        ...game2,
+        data: {
+          ...game2.data,
+          official: { type: 'winner', matchName: 'Quali 1' },
+        },
+      } as GameNode;
+      renderTable({ games: [gameWithWinnerOfficial] });
+      expect(screen.getByText(/Winner of Quali 1/i)).toBeInTheDocument();
+    });
   });
 
   describe('Dynamic reference interactions', () => {

--- a/gamedays/api/tests/test_publish_creates_gameinfos.py
+++ b/gamedays/api/tests/test_publish_creates_gameinfos.py
@@ -257,6 +257,33 @@ class TestPublishCreatesGameinfos:
         gi = Gameinfo.objects.get(gameday=self.gameday)
         assert gi.officials.name == "Officials FC"   # NOT the "t3" UUID
 
+    @pytest.mark.parametrize(
+        "official_ref,expected_name",
+        [
+            ({"type": "winner", "matchName": "VF 2"}, "Gewinner VF 2"),
+            ({"type": "loser", "matchName": "VF 2"}, "Verlierer VF 2"),
+            ({"type": "rank", "place": 1, "stageName": "Vorrunde", "stageId": ""}, "Rank 1 Vorrunde"),
+            (
+                {"type": "groupRank", "place": 3, "groupName": "Pool B", "stageName": "Quali", "stageId": ""},
+                "Rank 3 in Pool B of Quali",
+            ),
+        ],
+    )
+    def test_publish_dynamic_official_resolved_to_readable_label(self, official_ref, expected_name):
+        """
+        Guards against cryptic official labels ("winner:game-<uuid>"). A ref's
+        official that references the winner/loser/rank of another game must
+        publish with a readable name just like home/away dynamics do.
+        """
+        import copy
+
+        state = copy.deepcopy(MINIMAL_CANVAS_STATE)
+        state["nodes"][-1]["data"]["official"] = official_ref
+        GamedayDesignerState.objects.create(gameday=self.gameday, state_data=state)
+        self._publish()
+        gi = Gameinfo.objects.get(gameday=self.gameday)
+        assert gi.officials.name == expected_name
+
     def test_republish_after_unlock_replaces_gameinfos(self):
         """
         Full unlock → edit → re-publish cycle:

--- a/gamedays/management/commands/fix_cryptic_officials.py
+++ b/gamedays/management/commands/fix_cryptic_officials.py
@@ -1,0 +1,199 @@
+"""Fix cryptic official team names from pre-fix canvas publishes.
+
+Before the fix in PR #1778, the gameday designer stored official refs as raw
+strings like ``winner:game-<uuid>``. On publish these became ``Team`` rows with
+cryptic names that showed up in the public gameday view.
+
+This command scans all ``Team`` rows matching the cryptic pattern, resolves each
+to its readable label via the gameday's canvas state, and renames the team
+in-place.  It does **not** touch ``Gameinfo`` rows, results, or any other data.
+
+Usage
+-----
+Dry-run (default)::
+
+    python manage.py fix_cryptic_officials
+
+Fix everything::
+
+    python manage.py fix_cryptic_officials --execute
+
+Scope to one gameday::
+
+    python manage.py fix_cryptic_officials --gameday 874 --execute
+
+Safety
+------
+* DRY-RUN by default — nothing is written without ``--execute``.
+* ``--execute`` runs inside a single transaction that is committed only after
+  all resolutions succeed; any failure rolls back everything.
+* Prints a before/after table of every change.
+* Only touches ``Team.name`` for rows matching the cryptic pattern — no deletes,
+  no cascade risk.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from gamedays.models import Gameday, GamedayDesignerState, Gameinfo, Team
+from gamedays.service.canvas_publish_service import CanvasPublishService
+
+CRYPTIC_RE = re.compile(r"^(winner|loser):game-([0-9a-f-]+)$")
+
+
+class Command(BaseCommand):
+    help = (
+        "Fix cryptic official team names ('winner:game-<uuid>') created by "
+        "pre-#1778 canvas publishes. Dry-run by default."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--execute", action="store_true",
+            help="Actually commit the changes. Without it, this is a dry-run.",
+        )
+        parser.add_argument(
+            "--gameday", type=int,
+            help="Scope to a single gameday (by id).",
+        )
+
+    def handle(self, *args, **opts):
+        execute = opts["execute"]
+        gameday_id = opts["gameday"]
+        mode = "EXECUTE" if execute else "DRY RUN"
+
+        self.stdout.write(self.style.WARNING(
+            f"=== fix_cryptic_officials [{mode}] ==="))
+
+        # 1. Find all cryptic official teams
+        cryptic_teams = Team.objects.filter(
+            name__regex=CRYPTIC_RE.pattern,
+        )
+        if gameday_id:
+            # Narrow to teams referenced by this gameday's Gameinfos
+            gameinfo_ids = list(
+                Gameinfo.objects.filter(gameday_id=gameday_id)
+                .values_list("officials_id", flat=True)
+            )
+            cryptic_teams = cryptic_teams.filter(id__in=gameinfo_ids)
+
+        cryptic_teams = list(cryptic_teams)
+        if not cryptic_teams:
+            self.stdout.write(self.style.SUCCESS(
+                "No cryptic official teams found. Nothing to do."))
+            return
+
+        self.stdout.write(f"Found {len(cryptic_teams)} cryptic official team(s).")
+
+        # 2. Resolve each to a readable label
+        changes = []  # (team_id, old_name, new_name, source)
+        unresolvable = []  # (team_id, name, reason)
+
+        for team in cryptic_teams:
+            match = CRYPTIC_RE.match(team.name)
+            if not match:
+                continue
+            ref_type, game_uuid = match.group(1), match.group(2)
+
+            # Find which gameday(s) reference this team
+            referencing_gis = Gameinfo.objects.filter(officials_id=team.id)
+            if gameday_id:
+                referencing_gis = referencing_gis.filter(gameday_id=gameday_id)
+
+            resolved = False
+            for gi in referencing_gis:
+                canvas_state = self._load_canvas_state(gi.gameday_id)
+                if not canvas_state:
+                    unresolvable.append((
+                        team.id, team.name,
+                        f"No canvas state for gameday {gi.gameday_id}",
+                    ))
+                    continue
+
+                standing = self._find_standing_for_uuid(
+                    canvas_state, game_uuid
+                )
+                if not standing:
+                    unresolvable.append((
+                        team.id, team.name,
+                        f"Game UUID {game_uuid} not found in canvas for gameday {gi.gameday_id}",
+                    ))
+                    continue
+
+                ref = {"type": ref_type, "matchName": standing}
+                new_name = CanvasPublishService._format_dynamic_ref(ref)
+                if new_name:
+                    changes.append((team.id, team.name, new_name, f"gameday {gi.gameday_id}"))
+                    resolved = True
+                    break  # one resolution per team is enough
+
+            if not resolved and team.id not in [u[0] for u in unresolvable]:
+                unresolvable.append((
+                    team.id, team.name,
+                    "No referencing Gameinfo found",
+                ))
+
+        # 3. Report
+        self._print_results(changes, unresolvable)
+
+        if not changes:
+            self.stdout.write(self.style.WARNING(
+                "No resolvable changes. Check unresolvable list above."))
+            return
+
+        # 4. Apply (or dry-run)
+        if execute:
+            try:
+                with transaction.atomic():
+                    for team_id, _old, new_name, _source in changes:
+                        Team.objects.filter(id=team_id).update(name=new_name)
+                self.stdout.write(self.style.SUCCESS(
+                    f"COMMITTED {len(changes)} team rename(s)."))
+            except Exception as exc:
+                raise CommandError(f"Failed (rolled back): {exc}")
+        else:
+            self.stdout.write(self.style.WARNING(
+                f"DRY RUN complete — {len(changes)} change(s) would be applied. "
+                "Re-run with --execute to commit."))
+
+    # -- helpers ---------------------------------------------------------------
+
+    @staticmethod
+    def _load_canvas_state(gameday_id):
+        """Return the state_data dict for a gameday, or None."""
+        try:
+            state = GamedayDesignerState.objects.get(gameday_id=gameday_id)
+            return state.state_data or {}
+        except GamedayDesignerState.DoesNotExist:
+            return None
+
+    @staticmethod
+    def _find_standing_for_uuid(canvas_state, game_uuid):
+        """Walk canvas nodes to find a game node whose id contains the UUID."""
+        nodes = canvas_state.get("nodes", [])
+        for node in nodes:
+            if node.get("type") != "game":
+                continue
+            node_id = node.get("id", "")
+            # Canvas game IDs look like "game-<uuid>"
+            if game_uuid in node_id:
+                data = node.get("data", {})
+                return data.get("standing")
+        return None
+
+    def _print_results(self, changes, unresolvable):
+        if changes:
+            self.stdout.write(self.style.SUCCESS("\nResolvable changes:"))
+            self.stdout.write(f"  {'Team ID':>8}  {'Old Name':<35}  {'New Name':<30}  Source")
+            for team_id, old, new, source in changes:
+                self.stdout.write(f"  {team_id:>8}  {old:<35}  {new:<30}  {source}")
+
+        if unresolvable:
+            self.stdout.write(self.style.WARNING("\nUnresolvable (manual fix needed):"))
+            for team_id, name, reason in unresolvable:
+                self.stdout.write(f"  Team {team_id} ({name}): {reason}")

--- a/gamedays/service/canvas_publish_service.py
+++ b/gamedays/service/canvas_publish_service.py
@@ -142,4 +142,16 @@ class CanvasPublishService:
                     defaults={"description": name, "location": ""},
                 )
                 return team
+            return fallback
+
+        # Dynamic references (winner/loser/standing/rank/groupRank/groupTeam):
+        # format a readable label, e.g. {type: "winner", matchName: "VF 2"}
+        # -> "Gewinner VF 2", mirroring home/away dynamic resolution.
+        name = self._format_dynamic_ref(official_ref)
+        if name:
+            team, _ = Team.objects.get_or_create(
+                name=name,
+                defaults={"description": name, "location": ""},
+            )
+            return team
         return fallback

--- a/gamedays/tests/management/test_fix_cryptic_officials.py
+++ b/gamedays/tests/management/test_fix_cryptic_officials.py
@@ -1,0 +1,151 @@
+import copy
+from io import StringIO
+
+from django.core.management import call_command, CommandError
+from django.test import TestCase
+
+from gamedays.models import (
+    Gameday,
+    GamedayDesignerState,
+    Gameinfo,
+    Gameresult,
+    Team,
+)
+from gamedays.tests.setup_factories.factories import (
+    GamedayFactory,
+    GameinfoFactory,
+    TeamFactory,
+)
+
+MINIMAL_CANVAS_STATE = {
+    "nodes": [
+        {
+            "id": "stage-1",
+            "type": "stage",
+            "parentId": "field-1",
+            "data": {"name": "Vorrunde", "stageType": "GROUP", "order": 0},
+        },
+        {
+            "id": "field-1",
+            "type": "field",
+            "parentId": None,
+            "data": {"name": "Platz 1", "order": 0},
+        },
+        {
+            "id": "game-aaaa-bbbb-cccc",
+            "type": "game",
+            "parentId": "stage-1",
+            "data": {"standing": "VF 2", "startTime": "10:00"},
+        },
+        {
+            "id": "game-dddd-eeee-ffff",
+            "type": "game",
+            "parentId": "stage-1",
+            "data": {
+                "standing": "Spiel 2",
+                "startTime": "11:00",
+                "official": {"type": "winner", "matchName": "VF 2"},
+            },
+        },
+    ],
+    "globalTeams": [],
+}
+
+
+class FixCrypticOfficialsTest(TestCase):
+    def setUp(self):
+        self.team = TeamFactory()
+        self.gameday = GamedayFactory()
+        self.cryptic_team = Team.objects.create(
+            name="winner:game-aaaa-bbbb-cccc",
+            description="winner:game-aaaa-bbbb-cccc",
+            location="",
+        )
+        self.gameinfo = GameinfoFactory(
+            gameday=self.gameday,
+            officials=self.cryptic_team,
+        )
+        GamedayDesignerState.objects.create(
+            gameday=self.gameday,
+            state_data=copy.deepcopy(MINIMAL_CANVAS_STATE),
+        )
+
+    def _call(self, execute=False, gameday=None):
+        out = StringIO()
+        call_command(
+            "fix_cryptic_officials",
+            execute=execute,
+            gameday=gameday,
+            stdout=out,
+        )
+        return out.getvalue()
+
+    def test_dry_run_does_not_change_team_name(self):
+        self._call()
+        self.cryptic_team.refresh_from_db()
+        assert self.cryptic_team.name == "winner:game-aaaa-bbbb-cccc"
+
+    def test_execute_renames_cryptic_team(self):
+        self._call(execute=True)
+        self.cryptic_team.refresh_from_db()
+        assert self.cryptic_team.name == "Gewinner VF 2"
+
+    def test_execute_prints_change_table(self):
+        output = self._call(execute=True)
+        assert "winner:game-aaaa-bbbb-cccc" in output
+        assert "Gewinner VF 2" in output
+
+    def test_no_cryptic_teams_found(self):
+        self.cryptic_team.delete()
+        output = self._call()
+        assert "No cryptic official teams found" in output
+
+    def test_scoped_to_single_gameday(self):
+        gameday2 = GamedayFactory()
+        cryptic2 = Team.objects.create(
+            name="loser:game-xxxx-yyyy-zzzz",
+            description="loser:game-xxxx-yyyy-zzzz",
+            location="",
+        )
+        GameinfoFactory(gameday=gameday2, officials=cryptic2)
+        GamedayDesignerState.objects.create(
+            gameday=gameday2,
+            state_data={
+                "nodes": [
+                    {
+                        "id": "game-xxxx-yyyy-zzzz",
+                        "type": "game",
+                        "parentId": "stage-1",
+                        "data": {"standing": "HF 1", "startTime": "10:00"},
+                    },
+                ],
+                "globalTeams": [],
+            },
+        )
+
+        # Scope to gameday1 — should only fix the first cryptic team
+        self._call(execute=True, gameday=self.gameday.pk)
+
+        self.cryptic_team.refresh_from_db()
+        assert self.cryptic_team.name == "Gewinner VF 2"
+
+        cryptic2.refresh_from_db()
+        assert cryptic2.name == "loser:game-xxxx-yyyy-zzzz"
+
+    def test_unresolvable_no_canvas_state(self):
+        GamedayDesignerState.objects.filter(gameday=self.gameday).delete()
+        output = self._call(execute=True)
+        assert "Unresolvable" in output
+        assert "No canvas state" in output
+        # Team name should remain unchanged
+        self.cryptic_team.refresh_from_db()
+        assert self.cryptic_team.name == "winner:game-aaaa-bbbb-cccc"
+
+    def test_unresolvable_uuid_not_in_canvas(self):
+        # Replace canvas state with one that doesn't contain the UUID
+        GamedayDesignerState.objects.filter(gameday=self.gameday).update(
+            state_data={"nodes": [], "globalTeams": []},
+        )
+        output = self._call(execute=True)
+        assert "Unresolvable" in output
+        assert "not found in canvas" in output

--- a/gamedays/tests/management/test_fix_cryptic_officials.py
+++ b/gamedays/tests/management/test_fix_cryptic_officials.py
@@ -96,6 +96,7 @@ class FixCrypticOfficialsTest(TestCase):
         assert "Gewinner VF 2" in output
 
     def test_no_cryptic_teams_found(self):
+        self.gameinfo.delete()
         self.cryptic_team.delete()
         output = self._call()
         assert "No cryptic official teams found" in output


### PR DESCRIPTION
Fixes the cryptic official/ref display when the ref is set to the winner of a previous game (e.g. `winner:game-6599acb6-...` shown in the public gameday view).

Closes #1779

**Root cause**
`handleOfficialChange` stored a selected winner/loser as `{ type: 'static', name: 'winner:game-<uuid>' }` — a raw internal node id. Home/away teams resolve to `Gewinner VF 2` via proper `winner`/`loser` references, but the ref slot published a team literally named `winner:game-<uuid>`.

**Changes**
- `GameTable.tsx`: dynamic options now carry their resolved `TeamReference` (winner/loser/rank/groupRank); `handleOfficialChange` stores it directly instead of a raw `winner:<uuid>` string. `renderOfficialCell` also displays `rank`/`groupRank` and legacy `winner:/loser:` static values.
- `canvas_publish_service._resolve_official`: resolve dynamic refs to readable labels (e.g. `Gewinner VF 2`) via `_format_dynamic_ref`, mirroring home/away.
- `fix_cryptic_officials` management command: fixes already-published gamedays by scanning cryptic `Team` rows and renaming them in-place via canvas state resolution.
- Added frontend + backend regression tests.

**Fixing already-published gamedays**

For gamedays with results already entered (cannot re-publish):

```bash
# Dry-run
python manage.py fix_cryptic_officials

# Fix all
python manage.py fix_cryptic_officials --execute

# Scope to one gameday
python manage.py fix_cryptic_officials --gameday 874 --execute
```

Safety: dry-run by default, transaction-wrapped, only touches `Team.name` for cryptic rows.

**Verification**
- Frontend: 1117 tests pass, `eslint ./src` 0 errors, `tsc --noEmit` clean.
- Backend: py_compile OK (pytest needs the LXC MariaDB test DB).
- CI: CodeQL + CircleCI green.