### PR TITLE
fix(ci): sequence create_production_release after promote_to_prerelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -879,6 +879,7 @@ workflows:
       - create_production_release:
           requires:
             - deploy_production
+            - promote_to_prerelease
           filters:
             tags:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
## Summary
- `promote_to_prerelease` and `create_production_release` both call `gh release edit` on the same tag but had no dependency on each other in the CircleCI workflow graph, so they could run in either order.
- When production's approval gate (`hold_production`) auto-approves quickly, `deploy_production`/`create_production_release` can finish *before* `promote_to_prerelease`, which then overwrites the release back to `prerelease=true` even though production deploy already succeeded.
- Observed on `v4.15.2`: `create_production_release` finished at 22:11:42Z, then `promote_to_prerelease` finished at 22:11:50Z and clobbered it back to prerelease. Confirmed the fix is needed by comparing job order across v4.15.0/v4.15.1 (lucky ordering) vs v4.15.2 (raced) vs v4.14.4 (correct ordering).

## Fix
Add `promote_to_prerelease` to `create_production_release`'s `requires`, guaranteeing it always runs last so its `--prerelease=false --latest` edit is the one that sticks.

## Test plan
- [x] `circleci config validate .circleci/config.yml` passes
- [ ] Next release: confirm `create_production_release` job in CircleCI waits for `promote_to_prerelease` before running, and the final GitHub release is not flagged prerelease

🤖 Generated with [Claude Code](https://claude.com/claude-code)