### PR TITLE
fix(ci): block out-of-sequence release builds from deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,41 @@ jobs:
             docker exec $APP_CONTAINER sh -c 'curl -f --max-time 10 https://www.google.com'
             docker-compose -f docker-compose.ci.yaml down -v
 
+  check_release_sequence:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Refuse to deploy a tag older than the currently released version
+          command: |
+            TAG="${CIRCLE_TAG}"
+            VERSION="${TAG#v}"
+            VERSION="${VERSION%%-rc.*}"
+            REPO="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+
+            # .release-please-manifest.json on master is the single source of
+            # truth for "what's the latest intended release" - fetch it fresh
+            # (not from this job's own checkout) so a delayed/redelivered
+            # webhook for an old tag can't race a newer one that already shipped.
+            LATEST=$(curl -sf "https://raw.githubusercontent.com/${REPO}/master/.release-please-manifest.json" | grep -o '"[0-9]\+\.[0-9]\+\.[0-9]\+"' | tr -d '"')
+
+            if [ -z "$LATEST" ]; then
+              echo "Could not read the current version from master's release-please manifest - failing closed"
+              exit 1
+            fi
+
+            echo "This build's tag: ${VERSION} (from ${TAG})"
+            echo "Currently released version (master manifest): ${LATEST}"
+
+            OLDEST=$(printf '%s\n%s\n' "$VERSION" "$LATEST" | sort -V | head -1)
+            if [ "$OLDEST" = "$VERSION" ] && [ "$VERSION" != "$LATEST" ]; then
+              echo "${TAG} (${VERSION}) is older than the currently released version (${LATEST})."
+              echo "This looks like a stale/out-of-order CI trigger (e.g. a delayed GitHub webhook redelivery for an old tag) - refusing to deploy so production isn't rolled backwards."
+              exit 1
+            fi
+
+            echo "${TAG} is current. Proceeding."
+
   deploy_staging:
     docker:
       - image: cimg/base:stable
@@ -806,10 +841,18 @@ workflows:
             branches:
               ignore: /.*/
 
+      - check_release_sequence:
+          filters:
+            tags:
+              only: /^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+            branches:
+              ignore: /.*/
+
       - deploy_staging:
           context: staging
           requires:
             - test_compose_network
+            - check_release_sequence
           filters:
             tags:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
@@ -840,6 +883,7 @@ workflows:
           type: approval
           requires:
             - test_compose_network
+            - check_release_sequence
           filters:
             tags:
               only: /^v?[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
## Summary
- v4.14.4's CircleCI pipeline was triggered by a GitHub webhook that arrived ~8 hours late, well after v4.15.0/v4.15.1/v4.15.2 had already shipped. The pipeline ran anyway and deployed v4.14.4 to production, silently rolling it backwards over the already-live v4.15.2.
- Root cause: `deploy_production` (and `deploy_staging`) have no concept of "is this tag actually current" - they just deploy whatever tag triggered them, in whatever order CircleCI happens to run them.

## Fix
New `check_release_sequence` job compares the tag being built against `.release-please-manifest.json` on `master` (fetched live, not from this build's own checkout) - the single source of truth for the currently-intended latest version. If the tag is older, it fails closed with a clear message instead of deploying.

Wired as a `requires` of `deploy_staging` and `hold_production`, so it transitively gates every real deploy path: `deploy_production`, `deploy_demo_production`, `promote_to_prerelease`, `create_production_release`.

## Test plan
- [x] `circleci config validate .circleci/config.yml` passes
- [x] Version-comparison logic manually verified for same/older/newer/double-digit-patch cases (e.g. `4.15.9` vs `4.15.10`)
- [ ] Next release: confirm `check_release_sequence` runs and passes for the current tag
- [ ] Optional: manually trigger a rebuild of an old tag (e.g. re-run an old pipeline) to confirm it's blocked with the expected error

Related to #1783 (fixed the prerelease-flag race that this same stale v4.14.4 build also triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)