### PR TITLE
feat: publish stage mysql on loopback-only 127.0.0.1:33062

### DIFF
--- a/deployed/docker-compose.staging.yaml
+++ b/deployed/docker-compose.staging.yaml
@@ -11,6 +11,8 @@ services:
       - "./mysql-data:/var/lib/mysql"
       - "./mysql-init:/docker-entrypoint-initdb.d:ro"
     env_file: ls.env.staging
+    ports:
+      - "127.0.0.1:33062:3306"
     networks:
       - backend
     healthcheck:


### PR DESCRIPTION
Stable endpoint for an SSH-tunneled DBeaver connection to stage; not reachable from the network.