### PR TITLE
ci(github): upload python coverage to Codecov on master

### DIFF
--- a/.github/workflows/part_build_test.yaml
+++ b/.github/workflows/part_build_test.yaml
@@ -39,7 +39,7 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           uv sync --extra test
       - name: 🚀🧪 Run Tests
-        run: uv run pytest --cov --junitxml=junit.xml -o junit_family=legacy
+        run: uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
         env:
           MYSQL_HOST: 0.0.0.0
           SECRET_KEY: 123456-TEST
@@ -59,6 +59,8 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: python
       - name: 🧪 Upload test results to Codecov
         # secrets not directly accessible https://stackoverflow.com/questions/72925899/github-actions-detect-if-secret-exists
         env:


### PR DESCRIPTION
## Problem

CircleCI runs coverage uploads (including the `python` flag), but master builds run on GitHub Actions, not CircleCI (the CircleCI workflow skips master). The GitHub master workflow already uploaded JS coverage, but the Python job never emitted a coverage report — `pytest --cov` without `--cov-report=xml` produces no `coverage.xml` — so Python coverage never reached Codecov on master.

## Fix

In `part_build_test.yaml` (master's Python job):
- emit `coverage.xml` via `--cov-report=xml`
- upload it explicitly with `files: coverage.xml` and `flags: python` (flag name matches CircleCI so reports merge cleanly)