### PR TITLE
fix: give stage mysql a second, non-internal network for port publishing

### DIFF
--- a/deployed/docker-compose.staging.yaml
+++ b/deployed/docker-compose.staging.yaml
@@ -15,6 +15,7 @@ services:
       - "127.0.0.1:33062:3306"
     networks:
       - backend
+      - db_access
     healthcheck:
       test: ["CMD", "sh", "-c", "mariadb -h localhost --skip-ssl -u root -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"]
       interval: 15s
@@ -97,6 +98,8 @@ services:
 networks:
   backend:
     internal: true
+  db_access:
+    internal: false
   egress:
     internal: false
   proxy:


### PR DESCRIPTION
Follow-up to #1792. Docker Compose 2.40.3 doesn't activate a published host port for a service whose only network is internal:true — reproduced with a minimal, unrelated test case. Adding a second non-internal network dedicated solely to mysql fixes the publish without loosening anything (mysql gains no outbound reach, staging-app's path is unchanged, port stays 127.0.0.1-only).