### PR TITLE
fix(gamedays): publish legacy gamedays on create instead of DRAFT

### DIFF
--- a/gamedays/forms.py
+++ b/gamedays/forms.py
@@ -4,6 +4,7 @@ from dal import autocomplete
 from django import forms
 from django.contrib.auth.models import User
 from django.forms import modelformset_factory, BaseFormSet, formset_factory, inlineformset_factory
+from django.utils import timezone
 
 from gamedays.models import Season, League, Gameday, Gameinfo, Team, SeasonLeagueTeam, ResourceUrl
 
@@ -223,10 +224,18 @@ class GamedayForm(forms.ModelForm):
             self.fields["season"].initial = last_season.id
 
     def save(self, user=None):
+        is_new = self.instance.pk is None
         gameday = super(GamedayForm, self).save(commit=False)
         gameday.author = self.context.author
         if self.context.init_format:
             gameday.format = "INITIAL_EMPTY"
+        if is_new:
+            # Legacy gamedays have no draft/design phase -- unlike the visual
+            # Designer, this form creates a fully-specified gameday in one
+            # submission, so it should be live immediately rather than
+            # inheriting the model's DRAFT default.
+            gameday.status = Gameday.STATUS_PUBLISHED
+            gameday.published_at = timezone.now()
         gameday.save()
         return gameday
 

--- a/gamedays/migrations/0042_publish_legacy_draft_gamedays.py
+++ b/gamedays/migrations/0042_publish_legacy_draft_gamedays.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+from django.utils import timezone
+
+
+def publish_legacy_gamedays(apps_module, schema_editor):
+    if apps_module is not None:
+        Gameday = apps_module.get_model("gamedays", "Gameday")
+    else:
+        # Allows direct unit testing against the current models (see
+        # gamedays/tests/migrations/test_publish_legacy_gamedays.py).
+        from gamedays.models import Gameday
+
+    # Legacy (non-Designer) gamedays have no draft/design phase, so a
+    # DRAFT/blank status here only ever means "created before the
+    # publish-on-create fix" rather than "still being designed". Designer
+    # gamedays (identified by a linked GamedayDesignerState) legitimately
+    # stay DRAFT while mid-design, so they're excluded.
+    Gameday.objects.filter(
+        designer_state__isnull=True,
+        status__in=["DRAFT", ""],
+    ).update(status="PUBLISHED", published_at=timezone.now())
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("gamedays", "0041_backfill_stage_category"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            publish_legacy_gamedays,
+            # No reverse: once merged with genuinely-published rows, the
+            # backfilled rows can no longer be distinguished, so there is no
+            # safe way to revert only the rows this migration touched.
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/gamedays/tests/migrations/test_publish_legacy_gamedays.py
+++ b/gamedays/tests/migrations/test_publish_legacy_gamedays.py
@@ -1,0 +1,49 @@
+import importlib
+
+from django.test import TestCase
+
+from gamedays.models import Gameday, GamedayDesignerState
+from gamedays.tests.setup_factories.factories import GamedayFactory
+
+_migration = importlib.import_module(
+    "gamedays.migrations.0042_publish_legacy_draft_gamedays"
+)
+
+
+class TestPublishLegacyGamedays(TestCase):
+    def test_publishes_legacy_gameday_stuck_in_draft(self):
+        gameday = GamedayFactory(status=Gameday.STATUS_DRAFT, published_at=None)
+
+        _migration.publish_legacy_gamedays(apps_module=None, schema_editor=None)
+
+        gameday.refresh_from_db()
+        assert gameday.status == Gameday.STATUS_PUBLISHED
+        assert gameday.published_at is not None
+
+    def test_publishes_legacy_gameday_with_blank_status(self):
+        gameday = GamedayFactory(status="", published_at=None)
+
+        _migration.publish_legacy_gamedays(apps_module=None, schema_editor=None)
+
+        gameday.refresh_from_db()
+        assert gameday.status == Gameday.STATUS_PUBLISHED
+        assert gameday.published_at is not None
+
+    def test_leaves_designer_draft_gameday_untouched(self):
+        gameday = GamedayFactory(status=Gameday.STATUS_DRAFT, published_at=None)
+        GamedayDesignerState.objects.create(gameday=gameday, state_data={})
+
+        _migration.publish_legacy_gamedays(apps_module=None, schema_editor=None)
+
+        gameday.refresh_from_db()
+        assert gameday.status == Gameday.STATUS_DRAFT
+        assert gameday.published_at is None
+
+    def test_leaves_already_advanced_gameday_untouched(self):
+        gameday = GamedayFactory(status=Gameday.STATUS_IN_PROGRESS, published_at=None)
+
+        _migration.publish_legacy_gamedays(apps_module=None, schema_editor=None)
+
+        gameday.refresh_from_db()
+        assert gameday.status == Gameday.STATUS_IN_PROGRESS
+        assert gameday.published_at is None

--- a/gamedays/tests/test_forms.py
+++ b/gamedays/tests/test_forms.py
@@ -15,6 +15,7 @@ from gamedays.tests.setup_factories.factories import (
     TeamFactory,
     GameinfoFactory,
     GameresultFactory,
+    GamedayFactory,
     SeasonFactory,
     LeagueFactory,
     UserFactory,
@@ -88,6 +89,61 @@ class TestGamedayForm(TestCase):
         gameday = form.save()
         assert gameday.author == user
         assert gameday.format == "6_2"
+
+    def test_gameday_form_publishes_new_gameday(self):
+        season = SeasonFactory(name="2026")
+        league = LeagueFactory(name="League C")
+        user = UserFactory(username="LeagueOrgC")
+
+        data = {
+            "name": "New Gameday",
+            "season": season.id,
+            "league": league.id,
+            "date": date.today(),
+            "start": time(10, 0),
+            "address": "Stadium",
+        }
+
+        form = GamedayForm(
+            data=data, context=GamedayFormContext(user, init_format=True)
+        )
+        assert form.is_valid(), form.errors
+        gameday = form.save()
+
+        assert gameday.status == Gameday.STATUS_PUBLISHED
+        assert gameday.published_at is not None
+
+    def test_gameday_form_does_not_republish_existing_gameday(self):
+        season = SeasonFactory(name="2027")
+        league = LeagueFactory(name="League D")
+        user = UserFactory(username="LeagueOrgD")
+        existing = GamedayFactory(
+            season=season,
+            league=league,
+            status=Gameday.STATUS_IN_PROGRESS,
+            published_at=None,
+        )
+
+        data = {
+            "name": "Renamed Gameday",
+            "season": season.id,
+            "league": league.id,
+            "date": date.today(),
+            "start": time(11, 0),
+            "address": "New Address",
+        }
+
+        form = GamedayForm(
+            data=data,
+            instance=existing,
+            context=GamedayFormContext(user, init_format=False),
+        )
+        assert form.is_valid(), form.errors
+        gameday = form.save()
+
+        assert gameday.name == "Renamed Gameday"
+        assert gameday.status == Gameday.STATUS_IN_PROGRESS
+        assert gameday.published_at is None
 
 
 class TestGamedayFormatForm(TestCase):


### PR DESCRIPTION
## Summary
- Legacy-created gamedays (the non-Designer creation flow) have no draft/design phase, so falling back to the model's `DRAFT` default status was unintentional — `GamedayForm` never exposes `status`, and score entry never promotes a gameday out of `DRAFT`. A gameday could be played in full while permanently hidden from the progress dashboard, which excludes `DRAFT` gamedays (#1742).
- `GamedayForm.save()` now sets `status=PUBLISHED` + `published_at` when creating a brand-new gameday (`instance.pk is None`), leaving edits of existing gamedays untouched.
- One-off data migration (`0042_publish_legacy_draft_gamedays`) backfills existing legacy gamedays stuck at `DRAFT`/blank status, explicitly excluding anything with a `GamedayDesignerState` (genuine in-progress Designer drafts, which must stay `DRAFT`). No reverse migration — once merged with genuinely-published rows there's no safe way to tell them apart again.

## Test plan
- [x] New tests in `gamedays/tests/test_forms.py`: create publishes, update of an existing gameday leaves status untouched
- [x] New tests in `gamedays/tests/migrations/test_publish_legacy_gamedays.py`: DRAFT and blank-status legacy gamedays get published; Designer-linked DRAFT and already-advanced gamedays are left alone
- [x] `pytest gamedays journey` — 446 passed, 1 xfailed, no regressions
- [x] `manage.py makemigrations --check` — no model drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aQxrgm9E4BRD4VynRBWfE