### PR TITLE
feat: report maintenance_mode on the health-check endpoint

### DIFF
--- a/league_manager/tests/test_health_check.py
+++ b/league_manager/tests/test_health_check.py
@@ -1,5 +1,8 @@
 import pytest
-from django.urls import reverse
+from django.core.cache import cache
+
+from league_manager.constants import MAINTENANCE_CONFIG_CACHE_KEY
+from league_manager.models import SiteConfiguration
 
 
 @pytest.mark.django_db
@@ -10,3 +13,33 @@ def test_health_check_endpoint(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "healthy"
+
+
+@pytest.mark.django_db
+def test_health_check_reports_maintenance_mode_off_by_default(client):
+    config, _ = SiteConfiguration.objects.get_or_create(id=1)
+    config.maintenance_mode = False
+    config.save()
+    cache.delete(MAINTENANCE_CONFIG_CACHE_KEY)
+
+    response = client.get("/health/")
+
+    assert response.status_code == 200
+    assert response.json()["maintenance_mode"] is False
+
+
+@pytest.mark.django_db
+def test_health_check_reports_maintenance_mode_on(client):
+    config, _ = SiteConfiguration.objects.get_or_create(id=1)
+    config.maintenance_mode = True
+    config.save()
+    cache.delete(MAINTENANCE_CONFIG_CACHE_KEY)
+
+    response = client.get("/health/")
+
+    assert response.status_code == 200
+    assert response.json()["maintenance_mode"] is True
+
+    config.maintenance_mode = False
+    config.save()
+    cache.delete(MAINTENANCE_CONFIG_CACHE_KEY)

--- a/league_manager/urls.py
+++ b/league_manager/urls.py
@@ -19,13 +19,19 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_view
 from django.contrib.sitemaps.views import sitemap
+from django.core.cache import cache
 from django.http import JsonResponse
 from django.urls import path, include
 from django.views import View
 from django.views.generic import TemplateView, RedirectView
 
 from gamedays.constants import LEAGUE_GAMEDAY_LIST
-from league_manager.constants import LEAGUE_MANAGER_MAINTENANCE, CLEAR_CACHE
+from league_manager.constants import (
+    LEAGUE_MANAGER_MAINTENANCE,
+    CLEAR_CACHE,
+    MAINTENANCE_CONFIG_CACHE_KEY,
+)
+from league_manager.models import SiteConfiguration
 
 
 class HealthCheckView(View):
@@ -40,7 +46,13 @@ class HealthCheckView(View):
     """
 
     def get(self, request):
-        return JsonResponse({"status": "healthy"})
+        config = cache.get(MAINTENANCE_CONFIG_CACHE_KEY)
+        if config is None:
+            db_config = SiteConfiguration.objects.first()
+            maintenance_mode = db_config.maintenance_mode if db_config else False
+        else:
+            maintenance_mode = config["mode_active"]
+        return JsonResponse({"status": "healthy", "maintenance_mode": maintenance_mode})
 
 
 from league_manager.views import ClearCacheView, robots_txt_view, database_error_view, DemoInfoView


### PR DESCRIPTION
## Summary
- The external hourly maintenance/games monitoring probe (companion infra change in the container repo) needs a reliable, unauthenticated way to check whether maintenance mode is active.
- The originally-assumed signal — a redirect on `GET /login/`, mirroring `container/healthcheck.sh` — doesn't actually work: in practice `SiteConfiguration.maintenance_pages` is scoped to specific write endpoints (`/gamedays/gameday/new/`, passcheck transfers, officials sign-up, etc.), never `/login/`.
- `/health/` now reports `maintenance_mode` directly as a JSON field, reusing the same cache-then-DB-fallback `MaintenanceModeMiddleware` already uses, so there's a single source of truth and no added DB load on this frequently-polled endpoint.

## Test plan
- [x] Extended `league_manager/tests/test_health_check.py` with two new cases (maintenance off / on) — written first, confirmed failing (`KeyError: 'maintenance_mode'`) before the view change.
- [x] `MYSQL_HOST=... uv run pytest league_manager/tests/test_health_check.py league_manager/tests/test_views.py -v` — 13 passed, including the existing `TestMaintenanceView` (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hgivgx8FDAUaZPExFKsTe