### PR TITLE
fix(progress-dashboard): treat 1./2. Halbzeit statuses as live

### DIFF
--- a/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
+++ b/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
@@ -89,6 +89,32 @@ describe('useGameProgress', () => {
     expect(result.current.today[0].isStale).toBe(true);
   });
 
+  it('should count games in 1. Halbzeit / 2. Halbzeit as live (live scoreboard statuses)', async () => {
+    const mockGameday: Partial<GamedayProgress> = {
+      id: 4,
+      name: 'Live Scoreboard Gameday',
+      date: '2026-05-24',
+      start: '10:00:00',
+      games: [
+        { id: 401, status: '1. Halbzeit', scheduled: '10:00:00', field: 1, gameStarted: null, gameFinished: null, gameresult: null },
+        { id: 402, status: '2. Halbzeit', scheduled: '10:30:00', field: 2, gameStarted: null, gameFinished: null, gameresult: null },
+        { id: 403, status: GameStatus.PLANNED, scheduled: '11:00:00', field: 3, gameStarted: null, gameFinished: null, gameresult: null },
+      ],
+    };
+
+    vi.mocked(progressApi.list).mockResolvedValue([mockGameday as GamedayProgress]);
+
+    const { result } = renderHook(() => useGameProgress());
+
+    await vi.waitFor(() => expect(result.current.loading).toBe(false), { timeout: 1000 });
+
+    expect(result.current.live).toHaveLength(1);
+    expect(result.current.live[0].stats.live).toBe(2);
+    expect(result.current.live[0].stats.pending).toBe(1);
+    expect(result.current.live[0].stats.played).toBe(0);
+    expect(result.current.live[0].isStale).toBe(false);
+  });
+
   it('should calculate totalPlayedGamesToday correctly', async () => {
     const mockGamedays: Partial<GamedayProgress>[] = [
       {

--- a/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
+++ b/journey_dashboard/src/components/game-progress/__tests__/useGameProgress.test.ts
@@ -96,8 +96,8 @@ describe('useGameProgress', () => {
       date: '2026-05-24',
       start: '10:00:00',
       games: [
-        { id: 401, status: '1. Halbzeit', scheduled: '10:00:00', field: 1, gameStarted: null, gameFinished: null, gameresult: null },
-        { id: 402, status: '2. Halbzeit', scheduled: '10:30:00', field: 2, gameStarted: null, gameFinished: null, gameresult: null },
+        { id: 401, status: GameStatus.FIRST_HALF, scheduled: '10:00:00', field: 1, gameStarted: null, gameFinished: null, gameresult: null },
+        { id: 402, status: GameStatus.SECOND_HALF, scheduled: '10:30:00', field: 2, gameStarted: null, gameFinished: null, gameresult: null },
         { id: 403, status: GameStatus.PLANNED, scheduled: '11:00:00', field: 3, gameStarted: null, gameFinished: null, gameresult: null },
       ],
     };

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -1,13 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import { progressApi, type ProgressApiParams } from '../../../api/progressApi';
 import type { GamedayProgress, GamedayWithStats, GamedayStats, GameProgressState } from '../../../types/progressTypes';
-import { GameStatus } from '../../../types/progressTypes';
+import { GameStatus, LIVE_STATUSES } from '../../../types/progressTypes';
 import { getLastGameTime } from '../utils/gameTimeUtils';
 
 function calculateStats(gameday: GamedayProgress): GamedayStats {
   const total = gameday.games.length;
   const played = gameday.games.filter((g) => g.status === GameStatus.COMPLETED).length;
-  const live = gameday.games.filter((g) => g.status === GameStatus.IN_PROGRESS).length;
+  const live = gameday.games.filter((g) => LIVE_STATUSES.includes(g.status)).length;
   const pending = gameday.games.filter((g) => g.status === GameStatus.PLANNED).length;
 
   return {

--- a/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
+++ b/journey_dashboard/src/components/game-progress/hooks/useGameProgress.ts
@@ -7,7 +7,7 @@ import { getLastGameTime } from '../utils/gameTimeUtils';
 function calculateStats(gameday: GamedayProgress): GamedayStats {
   const total = gameday.games.length;
   const played = gameday.games.filter((g) => g.status === GameStatus.COMPLETED).length;
-  const live = gameday.games.filter((g) => LIVE_STATUSES.includes(g.status)).length;
+  const live = gameday.games.filter((g) => LIVE_STATUSES.some((status) => status === g.status)).length;
   const pending = gameday.games.filter((g) => g.status === GameStatus.PLANNED).length;
 
   return {

--- a/journey_dashboard/src/types/progressTypes.ts
+++ b/journey_dashboard/src/types/progressTypes.ts
@@ -70,4 +70,15 @@ export const GameStatus = {
   PLANNED: 'Geplant',
   IN_PROGRESS: 'Gestartet',
   COMPLETED: 'beendet',
+  FIRST_HALF: '1. Halbzeit',
+  SECOND_HALF: '2. Halbzeit',
 } as const;
+
+// Statuses that mean a game is live right now. The live scoreboard flow
+// (GameinfoWrapper) writes '1. Halbzeit' / '2. Halbzeit', while the REST PATCH
+// flow writes 'Gestartet'. All three must be treated as in progress.
+export const LIVE_STATUSES: readonly string[] = [
+  GameStatus.IN_PROGRESS,
+  GameStatus.FIRST_HALF,
+  GameStatus.SECOND_HALF,
+];

--- a/journey_dashboard/src/types/progressTypes.ts
+++ b/journey_dashboard/src/types/progressTypes.ts
@@ -74,10 +74,12 @@ export const GameStatus = {
   SECOND_HALF: '2. Halbzeit',
 } as const;
 
+type GameStatusValue = (typeof GameStatus)[keyof typeof GameStatus];
+
 // Statuses that mean a game is live right now. The live scoreboard flow
 // (GameinfoWrapper) writes '1. Halbzeit' / '2. Halbzeit', while the REST PATCH
 // flow writes 'Gestartet'. All three must be treated as in progress.
-export const LIVE_STATUSES: readonly string[] = [
+export const LIVE_STATUSES: readonly GameStatusValue[] = [
   GameStatus.IN_PROGRESS,
   GameStatus.FIRST_HALF,
   GameStatus.SECOND_HALF,


### PR DESCRIPTION
Fixes #1841

## Problem
`/gamedays/progress/` shows live games as pending (UPCOMING), and per-gameday totals silently drop games once they go live.

Two status vocabularies exist for `Gameinfo.status`:
- live scoreboard flow (`GameinfoWrapper`): `Geplant` → `1. Halbzeit` → `2. Halbzeit` → `beendet`
- REST PATCH flow: `Geplant` → `Gestartet` → `beendet`

The progress dashboard's `calculateStats()` only bucketed `Gestartet` as live, so a mid-game game written by the scoreboard (`1. Halbzeit`/`2. Halbzeit`) matched no bucket and vanished from played/live/pending totals. With `stats.live` stuck at 0, `isTodayGamedayStale()` treated the gameday as not-yet-started and rendered the UPCOMING badge.

## Fix
`journey_dashboard`: `LIVE_STATUSES` now treats `Gestartet`, `1. Halbzeit`, and `2. Halbzeit` as live in `calculateStats()`.

This is a frontend-only fix. It does not touch backend status handling (`gameinfo_wrapper.py`, `liveticker_service.py`, migrations) — that unification is tracked separately.

## Tests
- `useGameProgress.test.ts`: new case asserting `1. Halbzeit`/`2. Halbzeit` games count as live.

Run with:
- `cd journey_dashboard && npm run test:run && npm run eslint && npx tsc --noEmit`
